### PR TITLE
Add body size config option again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='tsd-file-api',
-    version='1.7.8',
+    version='1.7.9',
     description='A REST API for handling files and json',
     author='Leon du Toit',
     author_email='l.c.d.toit@usit.uio.no',

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -105,6 +105,7 @@ def set_config():
     define('tenant_string_pattern', _config['tenant_string_pattern'])
     define('export_chunk_size', _config['export_chunk_size'])
     define('valid_tenant', re.compile(r'{}'.format(_config['valid_tenant_regex'])))
+    define('max_body_size', _config['max_body_size'])
 
 
 set_config()
@@ -1649,7 +1650,7 @@ def main():
         ('/v1/(.*)/store/export', FileStreamerHandler, dict(backend='store')),
         ('/v1/(.*)/store/export/(.*)', FileStreamerHandler, dict(backend='store')),
     ], debug=options.debug)
-    app.listen(options.port)
+    app.listen(options.port, max_body_size=options.max_body_size)
     IOLoop.instance().start()
 
 


### PR DESCRIPTION
This was removed in a previous round of refactoring. Turns out that was a mistake.