### PR TITLE
Add maintenance mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='tsd-file-api',
-    version='1.13.0',
+    version='1.13.1',
     description='A REST API for handling files and json',
     author='Leon du Toit',
     author_email='l.c.d.toit@usit.uio.no',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
             'data/tsd/p11/export/fi*',
             'data/tsd/p11/export/bl*',
             'data/tsd/p11/export/.~lock*',
+            'data/tsd/p11/export/data-folder/s*',
             'config/file-api-config.yaml.example',
             'config/file-api.service',
         ]

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -671,12 +671,17 @@ class ResumablesHandler(AuthRequestHandler):
 
     def prepare(self):
         try:
+            self.err = 'Unauthorized'
+            if options.maintenance_mode_enabled:
+                self.set_status(503)
+                self.err = 'Service temporarily unavailable'
+                raise Exception(self.err)
             self.authnz = self.process_token_and_extract_claims(
                 check_tenant=self.check_tenant if self.check_tenant is not None else options.check_tenant
             )
         except Exception as e:
             logging.error(e)
-            raise e
+            self.finish({'message': self.err})
 
 
     def get(self, tenant, filename=None):

--- a/tsdfileapi/data/tsd/p11/export/data-folder/secret-data
+++ b/tsdfileapi/data/tsd/p11/export/data-folder/secret-data
@@ -1,0 +1,1 @@
+Ōdī et amō. Quārē id faciam fortasse requīris. Nesciō, sed fierī sentiō et excrucior.

--- a/tsdfileapi/resumables.py
+++ b/tsdfileapi/resumables.py
@@ -62,8 +62,6 @@ def session_scope(engine):
         yield session
         session.commit()
     except (OperationalError, IntegrityError, StatementError) as e:
-        logging.error(e)
-        logging.error("Rolling back transaction")
         session.rollback()
         raise e
     finally:

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -1479,6 +1479,10 @@ class TestFileApi(unittest.TestCase):
             shutil.rmtree(f'{dirs}')
         except OSError as e:
             pass
+        # posix backend
+        resp = requests.get(f'{self.export}/data-folder', headers=headers)
+        self.assertEqual(resp.status_code, 200)
+
 
 
     def test_ZZZ_get_file_from_dir(self):

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -2076,6 +2076,14 @@ class TestFileApi(unittest.TestCase):
         self.assertEqual(resp.status_code, 503)
         resp = requests.get(f'{self.base_url}/files/resumables')
         self.assertEqual(resp.status_code, 503)
+        resp = requests.put(f'{self.base_url}/files/stream/file')
+        self.assertEqual(resp.status_code, 503)
+        resp = requests.patch(f'{self.base_url}/files/stream/file')
+        self.assertEqual(resp.status_code, 503)
+        resp = requests.get(f'{self.base_url}/files/export/file1')
+        self.assertEqual(resp.status_code, 503)
+        resp = requests.head(f'{self.base_url}/files/export/file2')
+        self.assertEqual(resp.status_code, 503)
         resp = requests.post(maintenance_off)
 
 

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -2074,6 +2074,8 @@ class TestFileApi(unittest.TestCase):
         resp = requests.post(maintenance_on)
         resp = requests.put(self.sns_upload)
         self.assertEqual(resp.status_code, 503)
+        resp = requests.get(f'{self.base_url}/files/resumables')
+        self.assertEqual(resp.status_code, 503)
         resp = requests.post(maintenance_off)
 
 

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -2072,6 +2072,8 @@ class TestFileApi(unittest.TestCase):
         maintenance_on = f'{self.maintenance_url}?maintenance=on'
         maintenance_off = f'{self.maintenance_url}?maintenance=off'
         resp = requests.post(maintenance_on)
+        resp = requests.put(self.sns_upload)
+        self.assertEqual(resp.status_code, 503)
         resp = requests.post(maintenance_off)
 
 

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -2084,6 +2084,10 @@ class TestFileApi(unittest.TestCase):
         self.assertEqual(resp.status_code, 503)
         resp = requests.head(f'{self.base_url}/files/export/file2')
         self.assertEqual(resp.status_code, 503)
+        resp = requests.get(f'{self.base_url}/survey')
+        self.assertEqual(resp.status_code, 503)
+        resp = requests.put(f'{self.base_url}/survey/12345/submissions')
+        self.assertEqual(resp.status_code, 503)
         resp = requests.post(maintenance_off)
 
 

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -135,7 +135,8 @@ class TestFileApi(unittest.TestCase):
 
         # includes p19 - a random project number for integration testing
         cls.test_project = cls.config['test_project']
-        cls.base_url = 'http://localhost' + ':' + str(cls.config['port']) + '/v1/' + cls.test_project
+        cls.maintenance_url = f"http://localhost:{str(cls.config['port'])}/v1/admin"
+        cls.base_url = f"http://localhost:{str(cls.config['port'])}/v1/{cls.test_project}"
         cls.data_folder = cls.config['data_folder']
         cls.example_csv = os.path.normpath(cls.data_folder + '/example.csv')
         cls.an_empty_file = os.path.normpath(cls.data_folder + '/an-empty-file')
@@ -2066,6 +2067,14 @@ class TestFileApi(unittest.TestCase):
         )
         self.assertTrue(resp.status_code, 400)
 
+
+    def test_maintenance_mode(self):
+        maintenance_on = f'{self.maintenance_url}?maintenance=on'
+        maintenance_off = f'{self.maintenance_url}?maintenance=off'
+        resp = requests.post(maintenance_on)
+        resp = requests.post(maintenance_off)
+
+
 def main():
     tests = []
     base = [
@@ -2186,6 +2195,9 @@ def main():
     crypt = [
         'test_nacl_crypto'
     ]
+    maintenance = [
+        'test_maintenance_mode',
+    ]
     if len(sys.argv) == 2:
         print('usage:')
         print('python3 tsdfileapi/test_file_api.py config.yaml ARGS')
@@ -2223,6 +2235,8 @@ def main():
         tests.extend(apps)
     if 'crypt' in sys.argv:
         tests.extend(crypt)
+    if 'maintenance' in sys.argv:
+        tests.extend(maintenance)
     if 'all' in sys.argv:
         tests.extend(base)
         tests.extend(names)


### PR DESCRIPTION
Will enable draining requests from running instances, so deployments do not drop existing connections/requests due to restarts.

Also adds a fix for listing and exporting files from sub directories not owned by the process user.