### PR TITLE
Rabbitmq module and directory listing refinements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='tsd-file-api',
-    version='2.0.0',
+    version='2.0.1',
     description='A REST API for handling files and json',
     author='Leon du Toit',
     author_email='l.c.d.toit@usit.uio.no',

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -984,7 +984,6 @@ class StreamHandler(AuthRequestHandler):
                                         owner = options.api_user if (
                                             target.endswith(self.group_name) and is_target_root
                                         ) else self.requestor
-                                        logging.info(f'owner of {target} is {owner}')
                                         subprocess.call(['sudo', 'chown', f'{owner}:{self.group_name}', target])
                                 except (Exception, OSError):
                                     logging.error('could not set permissions on upload directories')

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -975,16 +975,21 @@ class StreamHandler(AuthRequestHandler):
                             logging.info(f'creating resource dir: {self.resource_dir}')
                             os.makedirs(self.resource_dir)
                             target = self.tenant_dir
+                            is_target_root = True
                             for _dir in url_dirs.split('/'):
                                 target += f'/{_dir}'
                                 try:
                                     if self.group_config['enabled']:
                                         subprocess.call(['chmod', '2770', target])
-                                        owner = options.api_user if target.endswith(self.group_name) else self.requestor
+                                        owner = options.api_user if (
+                                            target.endswith(self.group_name) and is_target_root
+                                        ) else self.requestor
+                                        logging.info(f'owner of {target} is {owner}')
                                         subprocess.call(['sudo', 'chown', f'{owner}:{self.group_name}', target])
                                 except (Exception, OSError):
                                     logging.error('could not set permissions on upload directories')
                                     raise Exception
+                                is_target_root = False
                     except Exception as e:
                         logging.error(e)
                         raise Exception

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -980,8 +980,8 @@ class StreamHandler(AuthRequestHandler):
                                 try:
                                     if self.group_config['enabled']:
                                         subprocess.call(['chmod', '2770', target])
-                                        # todo: if not root dir, should be user not api_user
-                                        subprocess.call(['sudo', 'chown', f'{options.api_user}:{self.group_name}', target])
+                                        owner = options.api_user if target.endswith(self.group_name) else self.requestor
+                                        subprocess.call(['sudo', 'chown', f'{owner}:{self.group_name}', target])
                                 except (Exception, OSError):
                                     logging.error('could not set permissions on upload directories')
                                     raise Exception

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -1526,6 +1526,14 @@ class TestFileApi(unittest.TestCase):
         # with necessary membership
         resp = requests.get(f'{self.stream}/p11-member-group', headers=headers)
         self.assertEqual(resp.status_code, 200)
+        # allowed
+        target = os.path.basename(self.so_sweet)
+        resp = requests.head(f'{self.stream}/p11-member-group/{target}', headers=headers)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue('Etag' in resp.headers.keys())
+        # not allowed
+        resp = requests.head(f'{self.stream}/p11-bla-group/{target}', headers=headers)
+        self.assertEqual(resp.status_code, 401)
 
 
     def test_ZZZ_get_file_from_dir(self):

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -1523,9 +1523,16 @@ class TestFileApi(unittest.TestCase):
         # will have APIgrant  level access control in addition
         resp = requests.get(f'{self.stream}/p11-bla-group', headers=headers)
         self.assertEqual(resp.status_code, 401)
-        # with necessary membership
+        # with necessary membership (reporting modified_date by default)
         resp = requests.get(f'{self.stream}/p11-member-group', headers=headers)
         self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.text)
+        self.assertTrue(data['files'][0]['modified_date'] is not None)
+        # leaving out modified_date if requested
+        resp = requests.get(f'{self.stream}/p11-member-group?disable_metadata=true', headers=headers)
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.text)
+        self.assertTrue(data['files'][0]['modified_date'] is None)
         # allowed
         target = os.path.basename(self.so_sweet)
         resp = requests.head(f'{self.stream}/p11-member-group/{target}', headers=headers)


### PR DESCRIPTION
* Use `pika.URLParameters` for connections - allows using `amqps` without a client cert, make TCP heartbeats configurable
* optional reporting of file `mtime` when listing the import directory - to enable sync
* more accurate sub-directory ownership for posix backends
* bump version to `2.0.1`