### PR TITLE
Enable incremental sync with modified-time checks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
   BSD 3-Clause License
 
-Copyright (c) 2018, the respective contributors, as shown by the AUTHORS file.
+Copyright (c) 2018 - 2020, the respective contributors, as shown by the AUTHORS file.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='tsd-file-api',
-    version='2.0.6',
+    version='2.1.0',
     description='A REST API for handling files and json',
     author='Leon du Toit',
     author_email='l.c.d.toit@usit.uio.no',

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -2092,7 +2092,7 @@ class ProxyHandler(AuthRequestHandler):
                     self.message = 'Cannot perform DELETE on base directory'
                     raise Exception
                 else:
-                    os.rmtree(self.filepath)
+                    shutil.rmtree(self.filepath)
                     return
             try:
                 # Allow the file to be deleted by changing the rights temporary of the parent directory

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1882,17 +1882,18 @@ class ProxyHandler(AuthRequestHandler):
         try:
             assert options.valid_tenant.match(tenant)
             self.path = self.export_dir
-            if not filename or os.path.isdir(f'{self.path}/{self.resource}'):
+            resource = url_unescape(self.resource)
+            if not filename or os.path.isdir(f'{self.path}/{resource}'):
                 if not self.allow_list:
                     self.message = 'Method not allowed'
                     self.set_status(403)
                     raise Exception
-                if filename and os.path.isdir(f'{self.path}/{self.resource}'):
-                    self.path += f'/{self.resource}'
+                if filename and os.path.isdir(f'{self.path}/{resource}'):
+                    self.path += f'/{resource}'
                 root = True if self.resource == self.path else False
                 self.list_files(self.path, tenant, root)
                 return
-            if not os.path.lexists(f'{self.path}/{self.resource}'):
+            if not os.path.lexists(f'{self.path}/{resource}'):
                     self.set_status(404)
                     self.message = 'Resource not found'
                     raise Exception
@@ -2034,6 +2035,7 @@ class ProxyHandler(AuthRequestHandler):
 
 
     def delete(self, tenant, filename):
+        # TODO: maybe allow deleting a dir
         self.message = 'Unknown error, please contact TSD'
         try:
             if not self.allow_delete:

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1793,15 +1793,17 @@ class ProxyHandler(AuthRequestHandler):
                             latest = path_stat.st_mtime
                             etag = self.mtime_to_digest(latest)
                             date_time = str(datetime.datetime.fromtimestamp(latest).isoformat())
+                            size, mime_type = self.get_file_metadata(file.path)
                         else:
                             date_time = None
                             etag = None
+                            size, mime_type = None, None
                         names.append(file.name)
                         times.append(date_time)
                         exportable.append(False)
                         reasons.append(None)
-                        sizes.append(None)
-                        mimes.append(None)
+                        sizes.append(size)
+                        mimes.append(mime_type)
                         owners.append(None)
                         etags.append(etag)
             file_info = []
@@ -1890,6 +1892,10 @@ class ProxyHandler(AuthRequestHandler):
                 root = True if self.resource == self.path else False
                 self.list_files(self.path, tenant, root)
                 return
+            if not os.path.lexists(f'{self.path}/{self.resource}'):
+                    self.set_status(404)
+                    self.message = 'Resource not found'
+                    raise Exception
             if not self.allow_export:
                 self.message = 'Method not allowed'
                 self.set_status(403)

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -1632,11 +1632,15 @@ class TestFileApi(unittest.TestCase):
                             data=lazy_file_reader(self.so_sweet),
                             headers=headers)
         self.assertEqual(resp.status_code, 201)
+        resp = requests.delete(f'{self.store_export}', headers=headers)
+        self.assertEqual(resp.status_code, 403)
+        resp = requests.delete(f'{self.store_export}/', headers=headers)
+        self.assertEqual(resp.status_code, 401)
         resp = requests.delete(f'{self.store_export}/topdir/bottomdir/file1', headers=headers)
         self.assertEqual(resp.status_code, 200)
         self.assertTrue('file1' not in os.listdir(dirs))
         resp = requests.delete(f'{self.store_export}/topdir/bottomdir', headers=headers)
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 200)
         resp = requests.delete(f'{self.store_export}/topdir/bottomdir/nofile', headers=headers)
         self.assertEqual(resp.status_code, 404)
         try:

--- a/tsdfileapi/utils.py
+++ b/tsdfileapi/utils.py
@@ -137,3 +137,8 @@ def move_data_to_folder(path, dest):
         logging.error(e)
         logging.error('could not move file: %s', path)
         return False
+
+def set_mtime(path, mtime):
+    mtime = mtime
+    atime = mtime
+    os.utime(path, (mtime, atime))


### PR DESCRIPTION
* clients can send information about file modified times, and the server will set them
* this can be used to perform incremental sync
* allow deleting directories