### PR TITLE
tsd-file-api: Extend dockerfiles for development and ready-to-use image (fix #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist/*
 tsdfileapi/data/large-file
 src/
 definitions
+RUN.sh
+tsd-api-client/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,92 @@
-FROM centos:7
+FROM centos:7 as base
 
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # install required packages
 RUN yum -y install epel-release
-RUN yum -y install python3-devel python3-pip python3-setuptools\
-    postgresql-devel rpm-build man gcc-c++ \
-    libpqxx-devel \
-    sudo rpm-build git \
-    openssl openssl-devel \
-    ruby-devel gcc make rubygems \
-    autoconf automake libtool
+RUN yum -y install \
+        autoconf           \
+        automake           \
+        gcc                \
+        gcc-c++            \
+        git                \
+        libpqxx-devel      \
+        libsodium          \
+        libtool            \
+        make               \
+        man                \
+        openssl            \
+        openssl-devel      \
+        postgresql-devel   \
+        python3-devel      \
+        python3-pip        \
+        python3-setuptools \
+        rpm-build          \
+        ruby-devel         \
+        rubygems           \
+        sudo
+
+
+##########################################################################################
+FROM base as rpm
+
 RUN pip3 install virtualenv virtualenv-tools3
-RUN gem install --no-ri --no-rdoc fpm
+
+# Workaround to get ruby2.3:
+# ERROR:  Error installing fpm:
+# 	ffi requires Ruby version >= 2.3.
+RUN yum -y install centos-release-scl-rh centos-release-scl
+RUN yum --enablerepo=centos-sclo-rh -y install rh-ruby23 rh-ruby23-ruby-devel
+RUN source /opt/rh/rh-ruby23/enable && gem install --no-ri --no-rdoc fpm
+
 # build rpms
 WORKDIR /file-api
 COPY requirements.txt ./
 RUN mkdir -p dist
-RUN fpm --verbose -s virtualenv -p /file-api/dist -t rpm --name tsd-file-api-venv --version 2.7 --prefix /opt/tsd-file-api-venv/virtualenv requirements.txt
+
+RUN source /opt/rh/rh-ruby23/enable && \
+     fpm --verbose -s virtualenv -p /file-api/dist  \
+     -t rpm --name tsd-file-api-venv --version 2.7  \
+     --prefix /opt/tsd-file-api-venv/virtualenv requirements.txt
 COPY . ./
+
 RUN python3 setup.py bdist --format=rpm
+
+##########################################################################################
+FROM base as dev
+
+ADD . /opt/tsd-file-api
+
+# Install dependencies
+RUN cd /opt/tsd-file-api && pip-3 install -r requirements.txt
+
+RUN cd /opt/tsd-file-api && python3 setup.py develop
+
+WORKDIR /opt
+
+EXPOSE 3003
+
+ENTRYPOINT ["python3", "/opt/tsd-file-api/tsdfileapi/api.py"]
+
+##########################################################################################
+FROM base as run
+
+ADD . /opt/tsd-file-api
+
+# Install dependencies
+RUN cd /opt/tsd-file-api && pip-3 install -r requirements.txt
+
+RUN cd /opt/tsd-file-api && \
+    python3 setup.py install --prefix /usr/ --single-version-externally-managed --root=/
+
+RUN    groupadd tsd \
+    &&  useradd  -g tsd tsd
+
+# RUN chown tsd:tsd $TSD_FILE_API_CONFIG
+
+USER tsd
+
+EXPOSE 3003
+
+ENTRYPOINT python3 /usr//lib/python3.6/site-packages/tsdfileapi/api.py "$TSD_FILE_API_CONFIG"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.5"
+
+services:
+  tsd-file-api-rpm:
+    image: tsd-file-api-rpm
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: rpm
+  tsd-file-api-dev:
+    image: tsd-file-api-dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    ports:
+      - 3003:3003
+    volumes:
+      - type: bind
+        source: ./etc/config.yaml
+        target: /etc/tsd/tsd-file-api/config.yaml
+  tsd-file-api:
+    image: tsd-file-api
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: run
+    ports:
+      - 3004:3003
+    environment:
+      - TSD_FILE_API_CONFIG=/etc/tsd/tsd-file-api/config.yaml
+    volumes:
+      - type: bind
+        source: ./etc/config.yaml
+        target: /etc/tsd/tsd-file-api/config.yaml

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -1,0 +1,20 @@
+port: 3003
+debug: True
+api_user: root
+token_check_tenant: True
+token_check_exp: True
+disallowed_start_chars: .~
+requestor_claim_name: user
+tenant_claim_name: proj
+valid_tenant_regex: ^[0-9a-z]+$
+tenant_string_pattern: pXX
+export_max_num_list: 100
+export_chunk_size: 512000
+max_body_size: 5368709120
+default_file_owner: pXX-nobody
+create_tenant_dir: True
+jwt_test_secret: jS25aQbePizfTsetg8LbFsNKl1W6wi4nQaBj705ofWA=
+jwt_secret: None
+nacl_public: {'public': 'mZQEzkyi7bCvmDVfHGsU/7HX1+gT/R3PkSnyDU4OaiY=', 'private': 'fTEB1MZz8MskkZHSIM9ypxJc4e45Z8fmLGGXkUrp1hQ='}
+log_level: info
+backends: {'disk': {'store': {'has_posix_ownership': False, 'export_max_num_list': None, 'import_path': '/tmp/pXX', 'export_path': '/tmp/pXX', 'allow_export': True, 'allow_list': True, 'allow_info': True, 'allow_delete': True, 'export_policy': {'default': {'enabled': False}}, 'group_logic': {'default_url_group': None, 'default_memberships': ['pXX-member-group'], 'enabled': False}, 'request_hook': {'enabled': False}}, 'apps_files': {'has_posix_ownership': False, 'export_max_num_list': None, 'import_path': '/tmp/pXX', 'export_path': '/tmp/pXX', 'allow_export': True, 'allow_list': True, 'allow_info': True, 'allow_delete': True, 'export_policy': {'default': {'enabled': False}}, 'group_logic': {'default_url_group': None, 'default_memberships': ['pXX-member-group'], 'enabled': False}, 'request_hook': {'enabled': False}}}, 'dbs': {'apps_tables': {'db': {'engine': 'sqlite', 'path': '/tmp/pXX', 'table_structure': None, 'mq': None}}}}


### PR DESCRIPTION
tsd-file-api: Extend dockerfiles for development and ready-to-use image (fix #10)

Motivation:

Extend the Docker image with  multi-stage builds to ease the development
in docker and ready-to-use image for dockerhub/harbour

Issue: https://github.com/unioslo/tsd-file-api/issues/10