### PR TITLE
Create installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -1,0 +1,20 @@
+# Installation
+
+## Synopsis
+
+Notes on installing `tsd-file-api` on various platforms.
+
+## RHEL/CentOS 8
+
+Besides
+
+* git
+* python3-dev
+
+the following packages are required:
+
+* postgresql-server
+* libpq-dev
+* libpq-devel.x86_64
+* a NaCl-derivative, like `libsodium`
+* optionally `sqlite-amalgamation` (see file `custom-sqlite-for-rhel7.md`)


### PR DESCRIPTION
Notes of how to install `tsd-file-api` on off-the-shelf installations of various GNU/Linux derivatives (and potentially other platforms).