### PR TITLE
Remove internal queuing and async proxying

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jwcrypto==0.6.0
-pyyaml==5.1.2
+pyyaml==5.4
 tornado==6.0.3
 click==7.0
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='tsd-file-api',
-    version='2.6.0',
+    version='2.6.1',
     description='A REST API for handling files and json',
     author='Leon du Toit',
     author_email='l.c.d.toit@usit.uio.no',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='tsd-file-api',
-    version='2.6.1',
+    version='2.7.0',
     description='A REST API for handling files and json',
     author='Leon du Toit',
     author_email='l.c.d.toit@usit.uio.no',

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -34,7 +34,6 @@ import libnacl.public
 import magic
 import tornado.httputil
 import tornado.log
-import tornado.queues
 import yaml
 
 from termcolor import colored
@@ -877,604 +876,7 @@ class ResumablesHandler(AuthRequestHandler):
 
 
 @stream_request_body
-class StreamHandler(AuthRequestHandler):
-
-    # pylint: disable=line-too-long
-
-    """
-    This class writes request data to files for PUT, POST and PATCH methods,
-    optionally calling request hooks after writing has finished.
-
-    The following steps are performed:
-
-    call initialize:
-    1. load backend config, depending on the url
-
-    call prepare
-    2. extract claims from the access token
-    3. validate url
-    4. load url parameters
-    5. process content-type header
-    6. if PATCH, prepare the resumable
-    7. rename the target file to .part (indicating an active upload)
-    8. optionally dispatch to a custom content-type request handler
-    9. open the file, set file permissions
-
-    call data_received
-    10. write data to target
-
-
-    call put, post, patch
-    11. close the file
-    12. if PATCH, either merge the new chunk or finalise the resumable
-
-    call on_finish, or on_connection_close
-    13. rename the file
-    14. optionally call a request hook (setting permissions and moving the file)
-
-    Resumable uploads therefore have the following request life cycle:
-    1. prepare
-        - setup
-        - checks
-    2. process
-        - open
-        - write
-        - close
-    3. complete
-        - merge chunk
-        - finalise
-
-    """
-
-    def decrypt_aes_key(self, b64encoded_pgpencrypted_key: str) -> str:
-        gpg = _import_keys(options.config)
-        key = base64.b64decode(b64encoded_pgpencrypted_key)
-        decr_aes_key = str(gpg.decrypt(key)).strip()
-        return decr_aes_key
-
-
-    def start_openssl_proc(self, output_file: str = None, base64: bool = True) -> subprocess.Popen:
-        cmd = ['openssl', 'enc', '-aes-256-cbc', '-d'] + self.aes_decryption_args_from_headers()
-        if output_file is not None:
-            cmd = cmd + ['-out', output_file]
-        if base64:
-            cmd = cmd + ['-a']
-        return subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE if output_file is None else None
-        )
-
-
-    def aes_decryption_args_from_headers(self) -> list:
-        try:
-            decr_aes_key = self.decrypt_aes_key(self.request.headers['Aes-Key'])
-        except Exception as e:
-            logging.error('decrypt_aes_key failed with:')
-            logging.error(e)
-            logging.error(traceback.format_exc())
-        if "Aes-Iv" in self.request.headers:
-            return ['-iv', self.request.headers["Aes-Iv"], '-K', decr_aes_key]
-        else:
-            return ['-pass', 'pass:%s' % decr_aes_key]
-
-
-    def handle_aes(self, content_type: str) -> None:
-        self.custom_content_type = content_type
-        self.proc = self.start_openssl_proc(output_file=self.path)
-
-
-    def handle_aes_octet_stream(self, content_type: str) -> None:
-        self.custom_content_type = 'application/aes'
-        self.proc = self.start_openssl_proc(output_file=self.path, base64=False)
-
-
-    def handle_tar(self, content_type: str, tenant_dir: str) -> None:
-        if 'gz' in content_type:
-            tarflags = '-xzf'
-        else:
-            tarflags = '-xf'
-        self.custom_content_type = content_type
-        self.proc = subprocess.Popen(
-            ['tar', '-C', tenant_dir, tarflags, '-'], stdin=subprocess.PIPE
-        )
-
-
-    def handle_tar_aes(self, content_type: str, tenant_dir: str) -> None:
-        if 'gz' in content_type:
-            tarflags = '-xzf'
-        else:
-            tarflags = '-xf'
-        self.custom_content_type = content_type
-        self.openssl_proc = self.start_openssl_proc()
-        self.tar_proc = subprocess.Popen(
-            ['tar', '-C', tenant_dir, tarflags, '-'], stdin=self.openssl_proc.stdout
-        )
-
-
-    def handle_gz(self, content_type: str, filemode: str) -> None:
-        self.custom_content_type = content_type
-        self.target_file = open(self.path, filemode)
-        self.gunzip_proc = subprocess.Popen(
-            ['gunzip', '-c', '-'],
-            stdin=subprocess.PIPE,
-            stdout=self.target_file,
-        )
-
-
-    def handle_gz_aes(self, content_type: str, filemode: str) -> None:
-        self.custom_content_type = content_type
-        self.target_file = open(self.path, filemode)
-        self.openssl_proc = self.start_openssl_proc()
-        self.gunzip_proc = subprocess.Popen(
-            ['gunzip', '-c', '-'],
-            stdin=self.openssl_proc.stdout,
-            stdout=self.target_file,
-        )
-
-    def handle_nacl_stream(self, headers: tornado.httputil.HTTPHeaders) -> None:
-        self.custom_content_type = headers['Content-Type']
-        self.nacl_stream_buffer = b''
-        try:
-            self.nacl_nonce = options.sealed_box.decrypt(
-                base64.b64decode(headers['Nacl-Nonce'])
-            )
-            self.nacl_key = options.sealed_box.decrypt(
-                base64.b64decode(headers['Nacl-Key'])
-            )
-        except Exception as e:
-            logging.error(e)
-            logging.error('Could not decrypt Nacl headers')
-            raise Exception
-        try:
-            self.nacl_chunksize = int(headers['Nacl-Chunksize'])
-        except KeyError:
-            logging.error('Missing Nacl-Chunksize header - cannot decrypt data')
-            raise Exception
-
-
-    def initialize(self, backend: str) -> None:
-        try:
-            self.backend = backend
-            self.endpoint = self.request.uri.split('/')[3]
-            self.tenant = tenant_from_url(self.request.uri)
-            assert options.valid_tenant.match(self.tenant)
-            self.import_dir = options.config['backends']['disk'][backend]['import_path']
-            self.tenant_dir = self.import_dir.replace(options.tenant_string_pattern, self.tenant)
-            self.request_hook = options.config['backends']['disk'][backend]['request_hook']
-            self.group_config = options.config['backends']['disk'][backend]['group_logic']
-            self.check_tenant = options.config['backends']['disk'][backend].get('check_tenant')
-            self.mq_config = options.config['backends']['disk'][backend].get('mq')
-        except AssertionError as e:
-            self.backend = backend
-            logging.error('URI does not contain a valid tenant')
-            raise e
-
-
-    @gen.coroutine
-    def prepare(self) -> Optional[Awaitable[None]]:
-        """
-        This sets up state for the part of the request handler which writes data to disk.
-
-        - authorization
-        - input validation
-        - file write mode
-        - content-type processing
-        - filename construction
-        - calling request-specific handlers
-        - ending requests which do not meet criteria
-
-        """
-        try:
-            self.completed_resumable_file = False
-            self.target_file = None
-            self.custom_content_type = None
-            self.path = None
-            self.path_part = None
-            self.chunk_order_correct = True
-            self.chunk_num = None
-            self.on_finish_called = False
-            filemodes = {'PUT': 'wb+', 'PATCH': 'wb+'}
-            try:
-                self.authnz = self.process_token_and_extract_claims(
-                    check_tenant=self.check_tenant if self.check_tenant is not None else options.check_tenant
-                )
-            except Exception as e:
-                logging.error(e)
-                raise Exception
-            try:
-                # 1. Check tenant reference
-                try:
-                    tenant = tenant_from_url(self.request.uri)
-                    self.tenant = tenant
-                    assert options.valid_tenant.match(tenant)
-                except AssertionError as e:
-                    logging.error('URI does not contain a valid tenant')
-                    raise e
-                # 2. get group param
-                try:
-                    self.group_name = url_unescape(self.get_query_argument('group'))
-                except Exception:
-                    self.group_name = tenant + '-member-group'
-                filemode = filemodes[self.request.method]
-                # 3. start processing the data
-                try:
-                    # 3.1 extract info from uri
-                    content_type = self.request.headers['Content-Type']
-                    uri_filename = self.request.uri.split('?')[0].split('/')[-1]
-                    filename = check_filename(url_unescape(uri_filename),
-                                              disallowed_start_chars=options.start_chars)
-                    # 3.2 optionally create dirs
-                    # 3.2.1 tenant dir
-                    if options.create_tenant_dir:
-                        if not os.path.lexists(self.tenant_dir):
-                            os.makedirs(self.tenant_dir)
-                    # 3.2.2 destination dir
-                    self.resource_dir = None
-                    try:
-                        resource_references = self.request.uri.split('?')[0].split('/')[5:]
-                        url_dirs = url_unescape('/'.join(resource_references[:-1]))
-                        self.resource_dir = os.path.normpath(f'{self.tenant_dir}/{url_dirs}')
-                        if not os.path.lexists(self.resource_dir):
-                            logging.info(f'creating resource dir: {self.resource_dir}')
-                            os.makedirs(self.resource_dir)
-                            target = self.tenant_dir
-                            for _dir in url_dirs.split('/'):
-                                target += f'/{_dir}'
-                                try:
-                                    if self.group_config['enabled']:
-                                        subprocess.call(['chmod', '2770', target])
-                                        owner = options.api_user  # so it can move the file into the dir
-                                        subprocess.call(['sudo', 'chown', f'{owner}:{self.group_name}', target])
-                                except (Exception, OSError):
-                                    logging.error('could not set permissions on upload directories')
-                                    raise Exception
-                    except Exception as e:
-                        logging.error(e)
-                        raise Exception
-                    # 3.3 handle resumable, if relavant
-                    if self.request.method == 'PATCH':
-                        # select resumable key:
-                        # then we remove the group name from url_dirs
-                        # because this is handled transparently
-                        # (for better or for worse)
-                        if self.group_config['enabled']:
-                            self.res_key = url_dirs.replace(self.group_name, '')[1:] # strip starting /
-                            self.res_key = None if not self.res_key else self.res_key
-                        else:
-                            self.res_key = url_dirs
-                        self.res = SerialResumable(self.tenant_dir, self.requestor)
-                        url_chunk_num = url_unescape(self.get_query_argument('chunk'))
-                        url_upload_id = url_unescape(self.get_query_argument('id'))
-                        self.chunk_num, \
-                        self.upload_id, \
-                        self.completed_resumable_file, \
-                        self.chunk_order_correct, \
-                        filename = self.res.prepare(
-                                self.tenant_dir,
-                                filename,
-                                url_chunk_num,
-                                url_upload_id,
-                                self.group_name,
-                                self.requestor,
-                                self.res_key
-                            )
-                        if not self.chunk_order_correct:
-                            logging.error('incorrect chunk order')
-                            raise ResumableIncorrectChunkOrderError
-                    # 3.4 ensure we do not write to active file
-                    self.path = os.path.normpath(self.tenant_dir + '/' + filename)
-                    self.path_part = self.path + '.' + str(uuid4()) + '.part'
-                    if os.path.lexists(self.path_part):
-                        logging.error('trying to write to partial file - killing request')
-                        raise Exception
-                    # 3.5 ensure idempotency
-                    if os.path.lexists(self.path):
-                        if os.path.isdir(self.path):
-                            logging.info('directory: %s already exists due to prior upload, removing', self.path)
-                            shutil.rmtree(self.path)
-                        else:
-                            logging.info('%s already exists, renaming to %s', self.path, self.path_part)
-                            os.rename(self.path, self.path_part)
-                            assert os.path.lexists(self.path_part)
-                            assert not os.path.lexists(self.path)
-                    # 3.6 rename
-                    self.path, self.path_part = self.path_part, self.path
-                    # 3.7 invoke custom content type handlers, if relevant
-                    if content_type == 'application/aes':
-                        self.handle_aes(content_type)
-                    elif content_type == 'application/aes-octet-stream':
-                        self.handle_aes_octet_stream(content_type)
-                    elif content_type in ['application/tar', 'application/tar.gz']:
-                        self.handle_tar(content_type, self.tenant_dir)
-                    elif content_type in ['application/tar.aes', 'application/tar.gz.aes']:
-                        self.handle_tar_aes(content_type, self.tenant_dir)
-                    elif content_type == 'application/gz':
-                        self.handle_gz(content_type, filemode)
-                    elif content_type == 'application/gz.aes':
-                        self.handle_gz_aes(content_type, filemode)
-                    elif content_type == 'application/octet-stream+nacl':
-                        self.handle_nacl_stream(self.request.headers)
-                        self.target_file = open(self.path, filemode)
-                        os.chmod(self.path, _RW______)
-                    else: # 3.8 no custom content type
-                        if self.request.method != 'PATCH':
-                            self.custom_content_type = None
-                            self.target_file = open(self.path, filemode)
-                            os.chmod(self.path, _RW______)
-                        elif self.request.method == 'PATCH':
-                            self.custom_content_type = None
-                            if not self.completed_resumable_file:
-                                self.target_file = self.res.open_file(self.path, filemode)
-                except KeyError:
-                    raise Exception('No content-type - do not know what to do with data')
-            # 3.9 handle any errors
-            except ResumableIncorrectChunkOrderError as e:
-                raise ResumableIncorrectChunkOrderError from e
-            except Exception as e:
-                try:
-                    if self.target_file:
-                        self.target_file.close()
-                    os.rename(self.path, self.path_part)
-                except AttributeError as e:
-                    logging.error(e)
-                    logging.error('No file to close after all - so nothing to worry about')
-                    raise e
-        except Exception as e:
-            logging.error('stream handler failed with:')
-            logging.error(traceback.format_exc())
-            info = 'stream processing failed'
-            if self.chunk_order_correct is False:
-                self.set_status(200)
-                info = 'chunk_order_incorrect'
-            self.finish({'message': info})
-
-
-    @gen.coroutine
-    def data_received(self, chunk: bytes) -> Optional[Awaitable[None]]:
-        try:
-            if not self.custom_content_type:
-                if self.request.method == 'PATCH':
-                    self.res.add_chunk(self.target_file, chunk)
-                else:
-                    self.target_file.write(chunk)
-            elif self.custom_content_type == 'application/octet-stream+nacl':
-                for byte in chunk:
-                    self.nacl_stream_buffer += bytes([byte])
-                    if len(self.nacl_stream_buffer) % self.nacl_chunksize == 0:
-                        decrypted = libnacl.crypto_stream_xor(
-                            self.nacl_stream_buffer,
-                            self.nacl_nonce,
-                            self.nacl_key
-                        )
-                        self.target_file.write(decrypted)
-                        self.nacl_stream_buffer = b''
-            elif self.custom_content_type in ['application/tar', 'application/tar.gz',
-                                              'application/aes']:
-                self.proc.stdin.write(chunk)
-                if not chunk:
-                    self.proc.stdin.flush()
-            elif self.custom_content_type in ['application/tar.aes', 'application/tar.gz.aes']:
-                self.openssl_proc.stdin.write(chunk)
-                if not chunk:
-                    self.openssl_proc.stdin.flush()
-                    self.tar_proc.stdin.flush()
-            elif self.custom_content_type == 'application/gz':
-                self.gunzip_proc.stdin.write(chunk)
-                if not chunk:
-                    self.gunzip_proc.stdin.flush()
-            elif self.custom_content_type == 'application/gz.aes':
-                self.openssl_proc.stdin.write(chunk)
-                if not chunk:
-                    self.openssl_proc.stdin.flush()
-                    self.gunzip_proc.stdin.flush()
-        except Exception as e:
-            logging.error(e)
-            logging.error("something went wrong with stream processing have to close file")
-            if self.target_file:
-                self.target_file.close()
-            os.rename(self.path, self.path_part)
-            self.send_error("something went wrong")
-
-    def put(self, tenant: str, uri_filename: str = None) -> None:
-        if not self.custom_content_type:
-            self.target_file.close()
-            os.rename(self.path, self.path_part)
-        elif self.custom_content_type == 'application/octet-stream+nacl':
-            if self.nacl_stream_buffer:
-                decrypted = libnacl.crypto_stream_xor(
-                            self.nacl_stream_buffer,
-                            self.nacl_nonce,
-                            self.nacl_key
-                        )
-                self.nacl_stream_buffer = b''
-                self.target_file.write(decrypted)
-            self.target_file.close()
-            os.rename(self.path, self.path_part)
-        elif self.custom_content_type in ['application/tar', 'application/tar.gz',
-                                          'application/aes']:
-            out, err = self.proc.communicate()
-            if self.custom_content_type == 'application/aes':
-                os.rename(self.path, self.path_part)
-        elif self.custom_content_type in ['application/tar.aes', 'application/tar.gz.aes']:
-            out, err = self.openssl_proc.communicate()
-            out, err = self.tar_proc.communicate()
-        elif self.custom_content_type == 'application/gz':
-            out, err = self.gunzip_proc.communicate()
-            self.target_file.close()
-            os.rename(self.path, self.path_part)
-        elif self.custom_content_type == 'application/gz.aes':
-            out, err = self.openssl_proc.communicate()
-            out, err = self.gunzip_proc.communicate()
-            self.target_file.close()
-            os.rename(self.path, self.path_part)
-        self.set_status(201)
-        self.write({'message': 'data streamed'})
-
-
-    def patch(self, tenant: str, uri_filename: str = None) -> None:
-        if not self.completed_resumable_file:
-            self.res.close_file(self.target_file)
-            # if the path to which we want to rename the file exists
-            # then we have been writing the same chunk concurrently
-            # from two different processes, so we should not do it
-            if not os.path.lexists(self.path_part):
-                os.rename(self.path, self.path_part)
-                filename = os.path.basename(self.path_part).split('.chunk')[0]
-                self.res.merge_chunk(
-                    self.tenant_dir,
-                    os.path.basename(self.path_part),
-                    self.upload_id,
-                    self.requestor
-                )
-            else:
-                self.write({'message': 'chunk_order_incorrect'})
-        else:
-            self.completed_resumable_filename = self.res.finalise(
-                self.tenant_dir,
-                os.path.basename(self.path_part),
-                self.upload_id,
-                self.requestor
-            )
-            filename = os.path.basename(self.completed_resumable_filename)
-        self.set_status(201)
-        self.write({
-            'filename': filename,
-            'id': self.upload_id,
-            'max_chunk': self.chunk_num,
-            'key': self.res_key})
-
-
-    def head(self, tenant: str, uri_filename: str = None) -> None:
-        self.set_status(201)
-
-
-    def on_finish(self) -> None:
-        """
-        Called after each request before closing the connection.
-
-        1. Clean up any open files, if an error occurred
-        2. Call the request hook, if configured
-
-        """
-        try:
-            if not self.target_file.closed:
-                self.target_file.close()
-                os.rename(self.path, self.path_part)
-        except AttributeError as e:
-            pass
-        resource_created = (
-            (self.request.method == 'PUT'
-            or (self.request.method == 'PATCH' and self.chunk_num == 'end'))
-            and self._status_code < 300
-        )
-        if resource_created:
-            try:
-                # switch path variables back
-                if not self.completed_resumable_file:
-                    path, path_part = self.path_part, self.path
-                else:
-                    path = self.completed_resumable_filename
-                resource_path = move_data_to_folder(path, self.resource_dir)
-                client_mtime = self.request.headers.get('Modified-Time')
-                if client_mtime:
-                    set_mtime(resource_path, float(client_mtime))
-            except Exception as e:
-                logging.info('could not move data to destination folder')
-                logging.info(e)
-            try:
-                if self.request_hook['enabled']:
-                    call_request_hook(
-                        self.request_hook['path'],
-                        [resource_path, self.requestor, options.api_user, self.group_name],
-                        as_sudo=self.request_hook['sudo']
-                    )
-            except Exception as e:
-                logging.info('problem calling request hook')
-                logging.info(e)
-            try:
-                message_data = {
-                        'path': resource_path,
-                        'requestor': self.requestor,
-                        'group': self.group_name,
-                    }
-                self.handle_mq_publication(
-                    mq_config=self.mq_config,
-                    data=message_data,
-                )
-                self.update_request_log(
-                    tenant=self.tenant,
-                    backend=self.backend,
-                    requestor=self.requestor,
-                    method=self.request.method,
-                    uri=self.request.headers.get('Original-Uri'),
-                    app=self.get_app_name(self.request.uri),
-                    claims=self.claims,
-                )
-            except Exception as e:
-                logging.error(e)
-            self.on_finish_called = True
-
-
-    def on_connection_close(self) -> None:
-        """
-        Called when clients close the connection.
-
-        1. Close open file, move it to destination
-
-        """
-        try:
-            if not self.target_file.closed:
-                self.target_file.close()
-                path = self.path
-                resource_created = (
-                    self.request.method == 'PUT' or (
-                        self.request.method == 'PATCH' and
-                        self.chunk_num == 'end'
-                    )
-                )
-                if resource_created:
-                    resource_path = move_data_to_folder(path, self.resource_dir)
-                    client_mtime = self.request.headers.get('Modified-Time')
-                    if client_mtime:
-                        set_mtime(resource_path, float(client_mtime))
-                    if self.request_hook['enabled']:
-                        call_request_hook(
-                            self.request_hook['path'],
-                            [resource_path, self.requestor, options.api_user, self.group_name],
-                            as_sudo=self.request_hook['sudo']
-                        )
-                # otherwise leave the partial upload in place, as is
-                # most likely a client that closed the connection
-                # while uploading a chunk, that was never finished
-                if not self.on_finish_called:
-                    try:
-                        message_data = {
-                                'path': resource_path,
-                                'requestor': self.requestor,
-                                'group': self.group_name,
-                            }
-                        self.handle_mq_publication(
-                            mq_config=self.mq_config,
-                            data=message_data,
-                        )
-                        self.update_request_log(
-                            tenant=self.tenant,
-                            backend=self.backend,
-                            requestor=self.requestor,
-                            method=self.request.method,
-                            uri=self.request.headers.get('Original-Uri'),
-                            app=self.get_app_name(self.request.uri),
-                            claims=self.claims,
-                        )
-                    except Exception as e:
-                        logging.error(e)
-        except (AttributeError, Exception) as e:
-            logging.error(e)
-
-
-@stream_request_body
-class ProxyHandler(AuthRequestHandler):
+class FileRequestHandler(AuthRequestHandler):
 
     def decrypt_aes_key(self, b64encoded_pgpencrypted_key: str) -> str:
         gpg = _import_keys(options.config)
@@ -1625,8 +1027,6 @@ class ProxyHandler(AuthRequestHandler):
 
     @gen.coroutine
     def prepare(self) -> Optional[Awaitable[None]]:
-        """Initiate internal async HTTP request to handle body.
-        """
         self.error = None
         self.completed_resumable_file = False
         self.target_file = None
@@ -1644,18 +1044,11 @@ class ProxyHandler(AuthRequestHandler):
                 raise Exception(self.error)
             # 1. Set up internal variables, check method supported
             try:
-                self.chunks = tornado.queues.Queue(1)
-                if self.request.method in ['HEAD', 'GET', 'DELETE']:
-                    #body = None
-                    pass
-                elif self.request.method == 'POST':
+                if self.request.method == 'POST':
                     self.set_status(405)
                     self.error = 'POST not supported'
                     logging.error(self.error)
                     raise Exception
-                else:
-                    #body = self.body_producer
-                    pass
                 self.listing_dir = False
             except Exception as e:
                 logging.error('Could not set up internal async variables')
@@ -1736,10 +1129,6 @@ class ProxyHandler(AuthRequestHandler):
                 raise e
             # 7. Set headers for internal request
             try:
-                headers = {
-                    'Authorization': f'Bearer {self.jwt}',
-                    'Original-Uri': self.request.uri
-                }
                 header_keys = self.request.headers.keys()
                 if 'Content-Type' not in header_keys:
                     content_type = 'application/octet-stream'
@@ -1752,20 +1141,11 @@ class ProxyHandler(AuthRequestHandler):
                             if required_nacl_header not in header_keys:
                                 logging.error(f'missing {required_nacl_header}')
                                 raise Exception
-                            headers[required_nacl_header] = self.request.headers[required_nacl_header]
-                        if int(headers['Nacl-Chunksize']) > options.max_nacl_chunksize:
+                        if int(self.request.headers['Nacl-Chunksize']) > options.max_nacl_chunksize:
                             self.error = f'Nacl-Chunksize larger than max allowed: {options.max_nacl_chunksize}'
                             logging.error(self.error)
                             raise Exception
-                if 'Aes-Key' in header_keys:
-                    headers['Aes-Key'] = self.request.headers['Aes-Key']
-                if 'Aes-Iv' in header_keys:
-                    headers['Aes-Iv'] = self.request.headers['Aes-Iv']
-                if 'Modified-Time' in header_keys:
-                    headers['Modified-Time'] = self.request.headers['Modified-Time']
-                headers['Content-Type'] = content_type
             except Exception as e:
-                self.error = 'Could not prepare headers for async request handling'
                 logging.error(e)
                 logging.error(self.error)
                 raise e
@@ -1796,237 +1176,153 @@ class ProxyHandler(AuthRequestHandler):
                 # then we are operating in the TSD import directory
                 if not self.filename and len(uri_parts) == 5: # no folder given
                     resource = work_dir # root dir
-            # 8.3 build internal url
-            self.resource = resource
-            params = '?group=%s&chunk=%s&id=%s' % (group_name, chunk_num, upload_id)
-            internal_url = f'http://localhost:{options.port}/v1/{tenant}/{self.namespace}/upload_stream/{resource}{params}'
             # 9. Do async request to handle incoming data
-            try:
-                if self.request.method in ('PUT', 'PATCH'):
-                    # otherwise we are serving something
-                    # so no need to pass data on
-                    #self.fetch_future = AsyncHTTPClient().fetch(
-                     #   internal_url,
-                      #  method=self.request.method,
-                       # body_producer=body,
-                        #request_timeout=12000.0, # 3 hours max
-                    #    headers=headers,
-                    #)
+            self.resource = resource
+            if self.request.method in ('PUT', 'PATCH'):
+                try:
+                    filemodes = {'PUT': 'wb+', 'PATCH': 'wb+'}
                     try:
-
-                        filemodes = {'PUT': 'wb+', 'PATCH': 'wb+'}
+                        # 9.1 get group param
                         try:
-                            self.authnz = self.process_token_and_extract_claims(
-                                check_tenant=self.check_tenant if self.check_tenant is not None else options.check_tenant
-                            )
+                            self.group_name = url_unescape(self.get_query_argument('group'))
+                        except Exception:
+                            self.group_name = tenant + '-member-group'
+                        filemode = filemodes[self.request.method]
+                        filename = self.filename
+                        # 3. start processing the data
+                        try:
+                            content_type = self.request.headers['Content-Type']
+                        except KeyError:
+                            raise Exception('No content-type - do not know what to do with data')
+                        # 3.1 extract info from uri
+                        # 3.2 optionally create dirs
+                        # 3.2.1 tenant dir
+                        if options.create_tenant_dir:
+                            if not os.path.lexists(self.tenant_dir):
+                                os.makedirs(self.tenant_dir)
+                        # 3.2.2 destination dir
+                        self.resource_dir = None
+                        try:
+                            url_dirs = os.path.dirname(resource)
+                            self.resource_dir = os.path.normpath(f'{self.tenant_dir}/{url_dirs}')
+                            if not os.path.lexists(self.resource_dir):
+                                logging.info(f'creating resource dir: {self.resource_dir}')
+                                os.makedirs(self.resource_dir)
+                                target = self.tenant_dir
+                                for _dir in url_dirs.split('/'):
+                                    target += f'/{_dir}'
+                                    try:
+                                        if self.group_config['enabled']:
+                                            subprocess.call(['chmod', '2770', target])
+                                            owner = options.api_user  # so it can move the file into the dir
+                                            subprocess.call(['sudo', 'chown', f'{owner}:{self.group_name}', target])
+                                    except (Exception, OSError):
+                                        logging.error('could not set permissions on upload directories')
+                                        raise Exception
                         except Exception as e:
                             logging.error(e)
                             raise Exception
-                        try:
-                            # 1. Check tenant reference
-                            try:
-                                tenant = tenant_from_url(self.request.uri)
-                                self.tenant = tenant
-                                assert options.valid_tenant.match(tenant)
-                            except AssertionError as e:
-                                logging.error('URI does not contain a valid tenant')
-                                raise e
-                            # 2. get group param
-                            try:
-                                self.group_name = url_unescape(self.get_query_argument('group'))
-                            except Exception:
-                                self.group_name = tenant + '-member-group'
-                            filemode = filemodes[self.request.method]
-                            # 3. start processing the data
-                            try:
-                                # 3.1 extract info from uri
-                                content_type = self.request.headers['Content-Type']
-                                uri_filename = self.request.uri.split('?')[0].split('/')[-1]
-                                filename = self.filename
-                                #filename = check_filename(url_unescape(uri_filename),
-                                #                          disallowed_start_chars=options.start_chars)
-                                # 3.2 optionally create dirs
-                                # 3.2.1 tenant dir
-                                if options.create_tenant_dir:
-                                    if not os.path.lexists(self.tenant_dir):
-                                        os.makedirs(self.tenant_dir)
-                                # 3.2.2 destination dir
-                                self.resource_dir = None
-                                try:
-                                    #resource_references = self.request.uri.split('?')[0].split('/')[5:]
-                                    #url_dirs = url_unescape('/'.join(resource_references[:-1]))
-                                    logging.info('[[[[[[[[[[')
-                                    logging.info(resource)
-                                    url_dirs = os.path.dirname(resource)
-                                    self.resource_dir = os.path.normpath(f'{self.tenant_dir}/{url_dirs}')
-                                    if not os.path.lexists(self.resource_dir):
-                                        logging.info(f'creating resource dir: {self.resource_dir}')
-                                        os.makedirs(self.resource_dir)
-                                        target = self.tenant_dir
-                                        for _dir in url_dirs.split('/'):
-                                            target += f'/{_dir}'
-                                            try:
-                                                if self.group_config['enabled']:
-                                                    subprocess.call(['chmod', '2770', target])
-                                                    owner = options.api_user  # so it can move the file into the dir
-                                                    subprocess.call(['sudo', 'chown', f'{owner}:{self.group_name}', target])
-                                            except (Exception, OSError):
-                                                logging.error('could not set permissions on upload directories')
-                                                raise Exception
-                                except Exception as e:
-                                    logging.error(e)
-                                    raise Exception
-                                # 3.3 handle resumable, if relavant
-                                if self.request.method == 'PATCH':
-                                    # select resumable key:
-                                    # then we remove the group name from url_dirs
-                                    # because this is handled transparently
-                                    # (for better or for worse)
-                                    if self.group_config['enabled']:
-                                        self.res_key = url_dirs.replace(self.group_name, '')[1:] # strip starting /
-                                        self.res_key = None if not self.res_key else self.res_key
-                                    else:
-                                        self.res_key = url_dirs
-                                    self.res = SerialResumable(self.tenant_dir, self.requestor)
-
-                                    url_chunk_num = url_unescape(self.get_query_argument('chunk'))
-
-                                    url_upload_id = url_unescape(self.get_query_argument('id', ''))
-                                    self.chunk_num, \
-                                    self.upload_id, \
-                                    self.completed_resumable_file, \
-                                    self.chunk_order_correct, \
-                                    filename = self.res.prepare(
-                                            self.tenant_dir,
-                                            filename,
-                                            url_chunk_num,
-                                            url_upload_id,
-                                            self.group_name,
-                                            self.requestor,
-                                            self.res_key
-                                        )
-                                    if not self.chunk_order_correct:
-                                        logging.error('incorrect chunk order')
-                                        raise ResumableIncorrectChunkOrderError
-                                # 3.4 ensure we do not write to active file
-                                self.path = os.path.normpath(self.tenant_dir + '/' + filename)
-                                self.path_part = self.path + '.' + str(uuid4()) + '.part'
-                                if os.path.lexists(self.path_part):
-                                    logging.error('trying to write to partial file - killing request')
-                                    raise Exception
-                                # 3.5 ensure idempotency
-                                if os.path.lexists(self.path):
-                                    if os.path.isdir(self.path):
-                                        logging.info('directory: %s already exists due to prior upload, removing', self.path)
-                                        shutil.rmtree(self.path)
-                                    else:
-                                        logging.info('%s already exists, renaming to %s', self.path, self.path_part)
-                                        os.rename(self.path, self.path_part)
-                                        assert os.path.lexists(self.path_part)
-                                        assert not os.path.lexists(self.path)
-                                # 3.6 rename
-                                self.path, self.path_part = self.path_part, self.path
-                                # 3.7 invoke custom content type handlers, if relevant
-                                if content_type == 'application/aes':
-                                    self.handle_aes(content_type)
-                                elif content_type == 'application/aes-octet-stream':
-                                    self.handle_aes_octet_stream(content_type)
-                                elif content_type in ['application/tar', 'application/tar.gz']:
-                                    self.handle_tar(content_type, self.tenant_dir)
-                                elif content_type in ['application/tar.aes', 'application/tar.gz.aes']:
-                                    self.handle_tar_aes(content_type, self.tenant_dir)
-                                elif content_type == 'application/gz':
-                                    self.handle_gz(content_type, filemode)
-                                elif content_type == 'application/gz.aes':
-                                    self.handle_gz_aes(content_type, filemode)
-                                elif content_type == 'application/octet-stream+nacl':
-                                    self.handle_nacl_stream(self.request.headers)
-                                    self.target_file = open(self.path, filemode)
-                                    os.chmod(self.path, _RW______)
-                                else: # 3.8 no custom content type
-                                    if self.request.method != 'PATCH':
-                                        self.custom_content_type = None
-                                        logging.info('>>>>>>>')
-                                        logging.info(self.path)
-                                        logging.info(self.path_part)
-                                        self.target_file = open(self.path, filemode)
-                                        os.chmod(self.path, _RW______)
-                                    elif self.request.method == 'PATCH':
-                                        self.custom_content_type = None
-                                        if not self.completed_resumable_file:
-                                            self.target_file = self.res.open_file(self.path, filemode)
-                            except KeyError:
-                                raise Exception('No content-type - do not know what to do with data')
-                        # 3.9 handle any errors
-                        except ResumableIncorrectChunkOrderError as e:
-                            raise ResumableIncorrectChunkOrderError from e
-                        except Exception as e:
-                            try:
-                                if self.target_file:
-                                    self.target_file.close()
+                        # 3.3 handle resumable, if relavant
+                        if self.request.method == 'PATCH':
+                            # select resumable key:
+                            # then we remove the group name from url_dirs
+                            # because this is handled transparently
+                            # (for better or for worse)
+                            if self.group_config['enabled']:
+                                self.res_key = url_dirs.replace(self.group_name, '')[1:] # strip starting /
+                                self.res_key = None if not self.res_key else self.res_key
+                            else:
+                                self.res_key = url_dirs
+                            self.res = SerialResumable(self.tenant_dir, self.requestor)
+                            url_chunk_num = url_unescape(self.get_query_argument('chunk'))
+                            url_upload_id = url_unescape(self.get_query_argument('id', ''))
+                            self.chunk_num, \
+                            self.upload_id, \
+                            self.completed_resumable_file, \
+                            self.chunk_order_correct, \
+                            filename = self.res.prepare(
+                                    self.tenant_dir,
+                                    filename,
+                                    url_chunk_num,
+                                    url_upload_id,
+                                    self.group_name,
+                                    self.requestor,
+                                    self.res_key
+                                )
+                            if not self.chunk_order_correct:
+                                logging.error('incorrect chunk order')
+                                raise ResumableIncorrectChunkOrderError
+                        # 3.4 ensure we do not write to active file
+                        self.path = os.path.normpath(self.tenant_dir + '/' + filename)
+                        self.path_part = self.path + '.' + str(uuid4()) + '.part'
+                        if os.path.lexists(self.path_part):
+                            logging.error('trying to write to partial file - killing request')
+                            raise Exception
+                        # 3.5 ensure idempotency
+                        if os.path.lexists(self.path):
+                            if os.path.isdir(self.path):
+                                logging.info('directory: %s already exists due to prior upload, removing', self.path)
+                                shutil.rmtree(self.path)
+                            else:
+                                logging.info('%s already exists, renaming to %s', self.path, self.path_part)
                                 os.rename(self.path, self.path_part)
-                            except AttributeError as e:
-                                logging.error(e)
-                                logging.error('No file to close after all - so nothing to worry about')
-                                raise e
+                                assert os.path.lexists(self.path_part)
+                                assert not os.path.lexists(self.path)
+                        # 3.6 rename
+                        self.path, self.path_part = self.path_part, self.path
+                        # 3.7 invoke custom content type handlers, if relevant
+                        if content_type == 'application/aes':
+                            self.handle_aes(content_type)
+                        elif content_type == 'application/aes-octet-stream':
+                            self.handle_aes_octet_stream(content_type)
+                        elif content_type in ['application/tar', 'application/tar.gz']:
+                            self.handle_tar(content_type, self.tenant_dir)
+                        elif content_type in ['application/tar.aes', 'application/tar.gz.aes']:
+                            self.handle_tar_aes(content_type, self.tenant_dir)
+                        elif content_type == 'application/gz':
+                            self.handle_gz(content_type, filemode)
+                        elif content_type == 'application/gz.aes':
+                            self.handle_gz_aes(content_type, filemode)
+                        elif content_type == 'application/octet-stream+nacl':
+                            self.handle_nacl_stream(self.request.headers)
+                            self.target_file = open(self.path, filemode)
+                            os.chmod(self.path, _RW______)
+                        else: # 3.8 no custom content type
+                            if self.request.method != 'PATCH':
+                                self.custom_content_type = None
+                                self.target_file = open(self.path, filemode)
+                                os.chmod(self.path, _RW______)
+                            elif self.request.method == 'PATCH':
+                                self.custom_content_type = None
+                                if not self.completed_resumable_file:
+                                    self.target_file = self.res.open_file(self.path, filemode)
+                    # 3.9 handle any errors
+                    except ResumableIncorrectChunkOrderError as e:
+                        raise ResumableIncorrectChunkOrderError from e
                     except Exception as e:
-                        logging.error('stream handler failed with:')
-                        logging.error(traceback.format_exc())
-                        info = 'stream processing failed'
-                        if self.chunk_order_correct is False:
-                            self.set_status(400)
-                            info = 'chunk_order_incorrect'
-                        self.finish({'message': info})
-            except Exception as e:
-                logging.error('Problem in async client')
-                logging.error(e)
-                raise e
-        except Exception as e:
+                        try:
+                            if self.target_file:
+                                self.target_file.close()
+                            os.rename(self.path, self.path_part)
+                        except AttributeError as e:
+                            logging.error(e)
+                            logging.error('No file to close after all - so nothing to worry about')
+                            raise e
+                except Exception as e:
+                    logging.error('stream handler failed with:')
+                    logging.error(traceback.format_exc())
+                    info = 'stream processing failed'
+                    if self.chunk_order_correct is False:
+                        self.set_status(400)
+                        info = 'chunk_order_incorrect'
+                    self.finish({'message': info})
+        except (Exception, AssertionError) as e:
             if self._status_code != 503:
                 self.set_status(401)
                 logging.error(self.error)
                 logging.error(e)
             self.finish()
-    """
-    @gen.coroutine
-    def body_producer(self, write: Callable) -> Any:
-        while True:
-            chunk = yield self.chunks.get()
-            if chunk is None:
-                return
-            yield write(chunk)
 
-    @gen.coroutine
-    def data_received(self, chunk: bytes) -> Optional[Awaitable[None]]:
-        yield self.chunks.put(chunk)
-
-    @gen.coroutine
-    def put(self, tenant: str, filename: str = None) -> None:
-        'Called after entire body has been read.'
-        yield self.chunks.put(None)
-        # wait for request to finish.
-        response = yield self.fetch_future
-        self.set_status(response.code)
-        self.write(response.body)
-
-    @gen.coroutine
-    def patch(self, tenant: str, filename: str = None) -> None:
-        'Called after entire body has been read.'
-        yield self.chunks.put(None)
-        # wait for request to finish.
-        response = yield self.fetch_future
-        code = response.code
-        body = response.body
-        try:
-            resp = json.loads(response.body)
-            if resp['message'] == 'chunk_order_incorrect':
-                code = 400
-                body = resp
-        except Exception:
-            pass
-        self.set_status(code)
-        self.write(body)
-        """
     @gen.coroutine
     def data_received(self, chunk: bytes) -> Optional[Awaitable[None]]:
         try:
@@ -2034,7 +1330,6 @@ class ProxyHandler(AuthRequestHandler):
                 if self.request.method == 'PATCH':
                     self.res.add_chunk(self.target_file, chunk)
                 else:
-                    logging.info(chunk)
                     self.target_file.write(chunk)
             elif self.custom_content_type == 'application/octet-stream+nacl':
                 for byte in chunk:
@@ -2670,9 +1965,8 @@ class ProxyHandler(AuthRequestHandler):
 
     def on_finish(self) -> None:
         resource_created = (
-            (self.request.method == 'PUT'
-            or (self.request.method == 'PATCH' and self.chunk_num == 'end'))
-            and self._status_code < 300
+            self.request.method == 'PUT'
+            or (self.request.method == 'PATCH' and self.chunk_num == 'end')
         )
         if (
             not options.maintenance_mode_enabled
@@ -2690,8 +1984,6 @@ class ProxyHandler(AuthRequestHandler):
                             path, path_part = self.path_part, self.path
                         else:
                             path = self.completed_resumable_filename
-                        logging.info(f'>>>>>>')
-                        logging.info(f'moving {path} to {self.resource_dir}')
                         resource_path = move_data_to_folder(path, self.resource_dir)
                         client_mtime = self.request.headers.get('Modified-Time')
                         if client_mtime:
@@ -2710,13 +2002,13 @@ class ProxyHandler(AuthRequestHandler):
                         logging.info('problem calling request hook')
                         logging.info(e)
                 message_data = {
-                    'path': None,
+                    'path': resource_path if resource_created else None,
                     'requestor': self.requestor,
-                    'group': None
+                    'group': self.group_name if resource_created else None,
                 }
                 self.handle_mq_publication(
                     mq_config=self.mq_config,
-                    data=message_data
+                    data=message_data,
                 )
                 if not self.listing_dir:
                     self.update_request_log(
@@ -2740,6 +2032,8 @@ class ProxyHandler(AuthRequestHandler):
 
         """
         try:
+            if self.on_finish_called:
+                return
             if not self.target_file.closed:
                 self.target_file.close()
                 path = self.path
@@ -2763,28 +2057,27 @@ class ProxyHandler(AuthRequestHandler):
                 # otherwise leave the partial upload in place, as is
                 # most likely a client that closed the connection
                 # while uploading a chunk, that was never finished
-                if not self.on_finish_called:
-                    try:
-                        message_data = {
-                                'path': resource_path,
-                                'requestor': self.requestor,
-                                'group': self.group_name,
-                            }
-                        self.handle_mq_publication(
-                            mq_config=self.mq_config,
-                            data=message_data,
-                        )
-                        self.update_request_log(
-                            tenant=self.tenant,
-                            backend=self.backend,
-                            requestor=self.requestor,
-                            method=self.request.method,
-                            uri=self.request.headers.get('Original-Uri'),
-                            app=self.get_app_name(self.request.uri),
-                            claims=self.claims,
-                        )
-                    except Exception as e:
-                        logging.error(e)
+                try:
+                    message_data = {
+                            'path': resource_path if resource_created else None,
+                            'requestor': self.requestor,
+                            'group': self.group_name if resource_created else None,
+                        }
+                    self.handle_mq_publication(
+                        mq_config=self.mq_config,
+                        data=message_data,
+                    )
+                    self.update_request_log(
+                        tenant=self.tenant,
+                        backend=self.backend,
+                        requestor=self.requestor,
+                        method=self.request.method,
+                        uri=self.request.headers.get('Original-Uri'),
+                        app=self.get_app_name(self.request.uri),
+                        claims=self.claims,
+                    )
+                except Exception as e:
+                    logging.error(e)
         except (AttributeError, Exception) as e:
             logging.error(e)
 
@@ -3229,23 +2522,20 @@ class Backends(object):
 
     optional_routes = {
         'files_import': [
-            ('/v1/(.*)/files/upload_stream', StreamHandler, dict(backend='files_import')),
-            ('/v1/(.*)/files/upload_stream/(.*)', StreamHandler, dict(backend='files_import')),
-            ('/v1/(.*)/files/stream', ProxyHandler, dict(backend='files_import', namespace='files', endpoint='stream')),
-            ('/v1/(.*)/files/stream/(.*)', ProxyHandler, dict(backend='files_import', namespace='files', endpoint='stream')),
+            ('/v1/(.*)/files/stream', FileRequestHandler, dict(backend='files_import', namespace='files', endpoint='stream')),
+            ('/v1/(.*)/files/stream/(.*)', FileRequestHandler, dict(backend='files_import', namespace='files', endpoint='stream')),
             ('/v1/(.*)/files/resumables', ResumablesHandler, dict(backend='files_import')),
             ('/v1/(.*)/files/resumables/(.*)', ResumablesHandler, dict(backend='files_import')),
         ],
         'files_export': [
-            ('/v1/(.*)/files/export', ProxyHandler, dict(backend='files_export', namespace='files', endpoint='export')),
-            ('/v1/(.*)/files/export/(.*)', ProxyHandler, dict(backend='files_export', namespace='files', endpoint='export')),
+            ('/v1/(.*)/files/export', FileRequestHandler, dict(backend='files_export', namespace='files', endpoint='export')),
+            ('/v1/(.*)/files/export/(.*)', FileRequestHandler, dict(backend='files_export', namespace='files', endpoint='export')),
         ],
         'survey': [
             ('/v1/(.*)/survey/crypto/key', NaclKeyHander),
-            ('/v1/(.*)/survey/([a-zA-Z_0-9]+/attachments.*)', ProxyHandler, dict(backend='survey', namespace='survey', endpoint=None)),
+            ('/v1/(.*)/survey/([a-zA-Z_0-9]+/attachments.*)', FileRequestHandler, dict(backend='survey', namespace='survey', endpoint=None)),
             ('/v1/(.*)/survey/resumables', ResumablesHandler, dict(backend='survey')),
             ('/v1/(.*)/survey/resumables/(.*)', ResumablesHandler, dict(backend='survey')),
-            ('/v1/(.*)/survey/upload_stream/(.*)', StreamHandler, dict(backend='survey')),
             ('/v1/(.*)/survey/([a-zA-Z_0-9]+)/metadata', GenericTableHandler, dict(backend='survey')),
             ('/v1/(.*)/survey/([a-zA-Z_0-9]+)/submissions', GenericTableHandler, dict(backend='survey')),
             ('/v1/(.*)/survey/([a-zA-Z_0-9]+)/audit', GenericTableHandler, dict(backend='survey')),
@@ -3257,22 +2547,19 @@ class Backends(object):
             ('/v1/(.*)/sns/(.*)/(.*)', SnsFormDataHandler, dict(backend='sns')),
         ],
         'publication': [
-            ('/v1/(.*)/publication/upload_stream', StreamHandler, dict(backend='publication')),
-            ('/v1/(.*)/publication/upload_stream/(.*)', StreamHandler, dict(backend='publication')),
-            ('/v1/(.*)/publication/import', ProxyHandler, dict(backend='publication', namespace='publication', endpoint='import')),
-            ('/v1/(.*)/publication/import/(.*)', ProxyHandler, dict(backend='publication', namespace='publication', endpoint='import')),
+            ('/v1/(.*)/publication/import', FileRequestHandler, dict(backend='publication', namespace='publication', endpoint='import')),
+            ('/v1/(.*)/publication/import/(.*)', FileRequestHandler, dict(backend='publication', namespace='publication', endpoint='import')),
             ('/v1/(.*)/publication/resumables', ResumablesHandler, dict(backend='publication')),
             ('/v1/(.*)/publication/resumables/(.*)', ResumablesHandler, dict(backend='publication')),
-            ('/v1/(.*)/publication/export', ProxyHandler, dict(backend='publication', namespace='publication', endpoint='export')),
-            ('/v1/(.*)/publication/export/(.*)', ProxyHandler, dict(backend='publication', namespace='publication', endpoint='export')),
+            ('/v1/(.*)/publication/export', FileRequestHandler, dict(backend='publication', namespace='publication', endpoint='export')),
+            ('/v1/(.*)/publication/export/(.*)', FileRequestHandler, dict(backend='publication', namespace='publication', endpoint='export')),
             ('/v1/(.*)/publication/tables/(.+)', GenericTableHandler, dict(backend='publication')),
             ('/v1/(.*)/publication/tables', GenericTableHandler, dict(backend='publication')),
         ],
         'apps_files': [
             ('/v1/(.*)/apps/.+/resumables', ResumablesHandler, dict(backend='apps_files')),
             ('/v1/(.*)/apps/.+/resumables/(.*)', ResumablesHandler, dict(backend='apps_files')),
-            ('/v1/(.*)/apps/upload_stream/(.*)', StreamHandler, dict(backend='apps_files')),
-            ('/v1/(.*)/apps/(.+/files.*)', ProxyHandler, dict(backend='apps_files', namespace='apps', endpoint=None)),
+            ('/v1/(.*)/apps/(.+/files.*)', FileRequestHandler, dict(backend='apps_files', namespace='apps', endpoint=None)),
         ],
         'apps_tables': [
             ('/v1/(.*)/apps/(.+)/tables/audit', GenericTableHandler, dict(backend='apps_tables')),
@@ -3284,7 +2571,7 @@ class Backends(object):
 
     database_backends = {
         'sqlite': SqliteBackend,
-        'postgres': PostgresBackend
+        'postgres': PostgresBackend,
     }
 
     def __init__(self, config: dict) -> None:

--- a/tsdfileapi/resumables.py
+++ b/tsdfileapi/resumables.py
@@ -251,7 +251,7 @@ class SerialResumable(AbstractResumable):
 
         """
         chunk_num = int(url_chunk_num) if url_chunk_num != 'end' else url_chunk_num
-        upload_id = str(uuid.uuid4()) if url_upload_id == 'None' else url_upload_id
+        upload_id = str(uuid.uuid4()) if not url_upload_id else url_upload_id
         chunk_filename = in_filename + '.chunk.' + url_chunk_num
         filename = upload_id + '/' + chunk_filename
         if chunk_num == 'end':

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -199,7 +199,7 @@ class TestFileApi(unittest.TestCase):
         cls.sns_upload = cls.base_url + '/sns/' + cls.config['test_keyid'] + '/' + cls.config['test_formid']
         cls.upload_sns_wrong = cls.base_url + '/sns/' + 'WRONG' + '/' + cls.config['test_formid']
         cls.stream = cls.base_url + '/files/stream'
-        cls.upload_stream = cls.base_url + '/files/upload_stream'
+
         cls.export = cls.base_url + '/files/export'
         cls.resumables = cls.base_url + '/files/resumables'
         cls.publication_import = cls.base_url + '/publication/import'
@@ -283,7 +283,7 @@ class TestFileApi(unittest.TestCase):
 
     def check_endpoints(self, headers: dict) -> None:
         files = {'file': ('example.csv', open(self.example_csv))}
-        for url in [self.upload, self.stream, self.upload_stream, self.upload]:
+        for url in [self.upload, self.stream, self.upload]:
             resp = requests.put(url, headers=headers, files=files)
             self.assertEqual(resp.status_code, 401)
             resp = requests.post(url, headers=headers, files=files)


### PR DESCRIPTION
For a long time the API has handled streaming uploads by pushing data into an in-memory queue, and then feeding those chunks to another internal endpoint via an async http handler. 

This pull request removes this, and opts instead for writing incoming chunks to disk. This removes a class of difficult to handle async errors that have popped up recently (most probably due to internal load). I have been running this in test for a while, and have not seen any performance regressions. On the contrary it seems a bit faster. 

It is a big diff, but it is mostly about moving code from what used to be the `StreamHandler` to what used to be the `ProxyHandler`, the latter now being called the `FileRequestHandler`.