### PR TITLE
Flag the response as 400 when chunk out of order

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1481,7 +1481,9 @@ class FileRequestHandler(AuthRequestHandler):
                     self.requestor
                 )
             else:
+                self.set_status(400)
                 self.write({'message': 'chunk_order_incorrect'})
+                return
         else:
             self.completed_resumable_filename = self.res.finalise(
                 self.tenant_dir,


### PR DESCRIPTION
The chunk number is deemed invalid for being "out of order", as indicated
by the corresponding part file being present, and so the patch request
does not actually succeed, so it makes sense to notify the client, and
since the chunk number originates with the client, a 400 seems
appropriate here.