### PR TITLE
Log `unlink` errors when merging a chunk

### DIFF
--- a/tsdfileapi/resumables.py
+++ b/tsdfileapi/resumables.py
@@ -665,8 +665,8 @@ class SerialResumable(AbstractResumable):
         finally:
             try:
                 os.unlink(out_lock)
-            except OSError:
-                pass
+            except Exception as e:
+                logging.exception(e)
         if chunk_num >= 5:
             target_chunk_num = chunk_num - 4
             old_chunk = chunk.replace('.chunk.' + str(chunk_num), '.chunk.' + str(target_chunk_num))


### PR DESCRIPTION
The error was ignored with a `pass` but logging it (with the
accompanying stack trace) may prove useful to debugging.