### PR TITLE
Only attempt unlink resumable lock file if latter was actually created 

### DIFF
--- a/tsdfileapi/resumables.py
+++ b/tsdfileapi/resumables.py
@@ -684,10 +684,11 @@ class SerialResumable(AbstractResumable):
                 fout.truncate(size_before_merge)
             raise e
         finally:
-            try:
-                os.unlink(out_lock)
-            except Exception as e:
-                logging.exception(e)
+            if chunk_num > 1:
+                try:
+                    os.unlink(out_lock)
+                except Exception as e:
+                    logging.exception(e)
         if chunk_num >= 5:
             target_chunk_num = chunk_num - 4
             old_chunk = chunk.replace('.chunk.' + str(chunk_num), '.chunk.' + str(target_chunk_num))


### PR DESCRIPTION
This fixes a small omission where we didn't see how attempting to
unconditionally unlinking the lock file is erroneous -- the file is only
attempted created for chunk numbers larger than 1. This fix will eliminate
"spurious" exceptions being logged for unlink errors that shouldn't even
be there.