### PR TITLE
Return 404 when resumable not found

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -906,7 +906,7 @@ class ResumablesHandler(AuthRequestHandler):
                         self.tenant_dir, secured_filename, upload_id, self.requestor, key=key
                     )
                 except ResumableNotFoundError as e:
-                    status = 400
+                    status = 404
                     raise e
             self.set_status(200)
             self.write(info)


### PR DESCRIPTION
This commit makes the API respond with HTTP status code 404 instead of
400, for GET requests for a resumable record for a file where no record
could be found. The 404 (Not Found) seems more appropriate for the
condition and helps clients distinguish between when a file has no
resumable records vs. all other [client] errors that 400 is returned for.