### PR TITLE
Return 404 if resumable isn't found during an end chunk request

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1505,12 +1505,16 @@ class FileRequestHandler(AuthRequestHandler):
                 self.write({'message': 'chunk_order_incorrect'})
                 return
         else:
-            self.completed_resumable_filename = self.res.finalise(
-                self.tenant_dir,
-                os.path.basename(self.path_part),
-                self.upload_id,
-                self.requestor
-            )
+            try:
+                self.completed_resumable_filename = self.res.finalise(
+                    self.tenant_dir,
+                    os.path.basename(self.path_part),
+                    self.upload_id,
+                    self.requestor
+                )
+            except ResumableNotFoundError:
+                self.set_status(404)
+                return
             filename = os.path.basename(self.completed_resumable_filename)
         self.set_status(201)
         self.write({

--- a/tsdfileapi/resumables.py
+++ b/tsdfileapi/resumables.py
@@ -590,7 +590,11 @@ class SerialResumable(AbstractResumable):
         chunks_dir = work_dir + '/' + upload_id
         if '.chunk.end' in last_chunk_filename:
             logging.info('deleting: %s', chunks_dir)
-            os.rename(out, final)
+            try:
+                os.rename(out, final)
+            except FileNotFoundError as e:
+                logging.error(e)
+                raise ResumableNotFoundError
             try:
                 shutil.rmtree(chunks_dir) # do not need to fail upload if this does not work
             except OSError as e:


### PR DESCRIPTION
This commit makes the API return the HTTP status code 404 ("Not Found")
when during processing of an "end" chunk request the renaming of the
temporary file accumulating the final resource being patched, fails due to
the file not being there.

Without such explicit handling, these requests would abort with the more
general HTTP status code 500 as set by Tornado on unhandled exceptions
like the error raised by the failing `os.rename` call.

With this change, a client can better determine with the retried request
whether the uploading did complete, after the first request for the end
chunk succeeded but came back with a server error (like those caused
by "spilling socket queues"). In other words, this allows for increased
confidence on part of the client in whether the uploading has been
finalised after all, as it attempts to recover from a preceding server
error by retrying the "end" chunk request.