### PR TITLE
Return HTTP error when a request processing code path raises an error

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1373,7 +1373,10 @@ class FileRequestHandler(AuthRequestHandler):
                             logging.error(e)
                             logging.error('No file to close after all - so nothing to worry about')
                             raise e
+                        raise e
                 except Exception as e:
+                    if self.get_status() < 400:
+                        self.set_status(500)
                     logging.error('stream handler failed with:')
                     logging.error(traceback.format_exc())
                     info = 'stream processing failed'


### PR DESCRIPTION
The `except` block at line 1367 must deal with just about any error that may be raised between it and line 1250, some of such errors not stemming from any other `except` block in between with these as such being runtime errors which the API would not be able to recover from to fulfil the request. For this reason the `except` block at line 1367 should re-raise the error it catches (or a derivative using `from`) because it doesn't really handle the error to a degree where the request can be fulfilled successfully. The [re-raised] error may then finally be caught by the `except` block at line 1376, which _always_ finishes the response (getting `on_finish` to be called) but, importantly, _without_ flagging the response with an error code. Because the errors it may catch may well be fatal for the request, this PR proposes to change the behaviour to have the first block re-raise the error after the "clean-up" that the block does (lines 1368-1375), and for the second block to appropriately flag the response with a HTTP "server error" status code (only if another error code hasn't already been set on it -- we don't want to potentially override a specific error status code already set, with a "server error" indiscriminately).

This change makes sure that the "false positives" which otherwise would end up producing "successful" responses in cases where things may have gone fatally wrong during request processing, do not occur.