### PR TITLE
Handle ESS migration

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -825,8 +825,9 @@ class FormDataHandler(GenericFormDataHandler):
             self.set_status(201)
             self.write({'message': 'data uploaded'})
         except StorageTemporarilyUnavailableError:
-            self.set_status(503, reason="project_storage_migrating")
-            self.write({"message": "project_storage_migrating"})
+            self.set_header("X-Project-Storage", "Migrating")
+            self.set_status(503, reason="Project Storage Migrating")
+            self.write({"message": "Project Storage Migrating"})
         except Exception:
             self.set_status(400)
             self.write({'message': 'could not upload data'})
@@ -852,8 +853,9 @@ class SnsFormDataHandler(GenericFormDataHandler):
             self.set_status(201)
             self.write({'message': 'data uploaded'})
         except StorageTemporarilyUnavailableError:
-            self.set_status(503, reason="project_storage_migrating")
-            self.write({"message": "project_storage_migrating"})
+            self.set_header("X-Project-Storage", "Migrating")
+            self.set_status(503, reason="Project Storage Migrating")
+            self.write({"message": "Project Storage Migrating"})
         except Exception:
             self.set_status(400)
             self.write({'message': 'could not upload data'})
@@ -946,7 +948,8 @@ class ResumablesHandler(AuthRequestHandler):
             )
             self.err = 'Unauthorized'
         except StorageTemporarilyUnavailableError:
-            self.set_status(503, reason="project_storage_migrating")
+            self.set_header("X-Project-Storage", "Migrating")
+            self.set_status(503, reason="Project Storage Migrating")
             self.finish()
         except Exception as e:
             self.finish()
@@ -1480,7 +1483,8 @@ class FileRequestHandler(AuthRequestHandler):
                         info = 'chunk_order_incorrect'
                     self.finish({'message': info})
         except StorageTemporarilyUnavailableError:
-            self.set_status(503, reason="project_storage_migrating")
+            self.set_header("X-Project-Storage", "Migrating")
+            self.set_status(503, reason="Project Storage Migrating")
             self.finish()
         except (Exception, AssertionError) as e:
             if self._status_code != 503:
@@ -2407,7 +2411,8 @@ class GenericTableHandler(AuthRequestHandler):
                     schema = self.tenant
                 self.db = PostgresBackend(options.pgpools.get(self.backend), schema=schema, requestor=self.requestor)
         except StorageTemporarilyUnavailableError:
-            self.set_status(503, reason="project_storage_migrating")
+            self.set_header("X-Project-Storage", "Migrating")
+            self.set_status(503, reason="Project Storage Migrating")
         except Exception as e:
             logging.error(e)
             if self._status_code != 503:
@@ -2786,8 +2791,9 @@ class AuditLogViewerHandler(AuthRequestHandler):
                 self.write(']')
                 self.flush()
         except StorageTemporarilyUnavailableError:
-            self.set_status(503, reason="project_storage_migrating")
-            self.write({'message': 'project_storage_migrating'})
+            self.set_header("X-Project-Storage", "Migrating")
+            self.set_status(503, reason="Project Storage Migrating")
+            self.write({'message': 'Project Storage Migrating'})
         except (psycopg2.errors.UndefinedTable, sqlite3.OperationalError) as e:
             logging.error(e)
             self.set_status(404)

--- a/tsdfileapi/db.py
+++ b/tsdfileapi/db.py
@@ -43,7 +43,8 @@ def get_projects_migration_status(conn: psycopg2.extensions.connection,) -> dict
         session.execute(
             """select
                     project_number,
-                    case when project_metadata->>'storage_backend' is null then 'hnas' end
+                    case when project_metadata->>'storage_backend' is null then 'hnas'
+                    else project_metadata->>'storage_backend' end
                 from projects
             """
         )

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -2637,7 +2637,8 @@ class TestFileApi(unittest.TestCase):
         # resumables
         resp = requests.get(self.resumables, headers=headers)
         self.assertEqual(resp.status_code, 503)
-        self.assertEqual(resp.reason, "project_storage_migrating")
+        self.assertEqual(resp.reason, "Project Storage Migrating")
+        self.assertEqual(resp.headers.get("X-Project-Storage"), "Migrating")
         # import
         resp = requests.put(
             f"{self.stream}/lol-file",
@@ -2645,7 +2646,8 @@ class TestFileApi(unittest.TestCase):
             headers=headers,
         )
         self.assertEqual(resp.status_code, 503)
-        self.assertEqual(resp.reason, "project_storage_migrating")
+        self.assertEqual(resp.reason, "Project Storage Migrating")
+        self.assertEqual(resp.headers.get("X-Project-Storage"), "Migrating")
         # now use ess
         with postgres_session(pool) as session:
             session.execute(

--- a/tsdfileapi/utils.py
+++ b/tsdfileapi/utils.py
@@ -93,6 +93,22 @@ def find_tenant_storage_path(
         return cache.get(tenant).get("storage_paths").get("hnas")
 
 
+def choose_storage(
+    *,
+    tenant: str,
+    endpoint_backend: str,
+    opts: tornado.options.OptionParser,
+    directory: str,
+) -> str:
+    split_on = "data/durable"
+    storage_path = find_tenant_storage_path(
+        tenant, endpoint_backend, opts,
+    ).split(split_on)
+    in_dir = directory.split(split_on)
+    out_dir = "".join([storage_path[0], split_on, in_dir[-1]])
+    return out_dir
+
+
 def call_request_hook(path: str, params: list, as_sudo: bool = True) -> None:
     if as_sudo:
         cmd = ['sudo']

--- a/tsdfileapi/utils.py
+++ b/tsdfileapi/utils.py
@@ -73,6 +73,8 @@ def find_tenant_storage_path(
                 "ess": None,
             }
         }
+    else:
+        cache[tenant]["storage_backend"] = opts.migration_statuses.get(tenant, default_storage_backend)
     if (
         opts.migration_statuses.get(tenant, default_storage_backend) == "ess"
         and not cache.get(tenant).get("storage_paths").get("ess")
@@ -100,6 +102,8 @@ def choose_storage(
     opts: tornado.options.OptionParser,
     directory: str,
 ) -> str:
+    if not directory.startswith("/tsd"):
+        return directory
     split_on = "data/durable"
     storage_path = find_tenant_storage_path(
         tenant, endpoint_backend, opts,

--- a/tsdfileapi/utils.py
+++ b/tsdfileapi/utils.py
@@ -9,11 +9,92 @@ import shlex
 import re
 import shutil
 
-from typing import Union
+from typing import Union, Optional
+
+import tornado.options
 
 _VALID_FORMID = re.compile(r'^[0-9]+$')
 _IS_REALISTIC_PGP_KEY_FINGERPRINT = re.compile(r'^[0-9A-Z]{16}$')
 _IS_VALID_UUID = re.compile(r'([a-f\d0-9-]{32,36})')
+
+
+def get_projects_migration_status() -> dict:
+    """
+    {
+        p11: storage_backend,
+        ...
+    }
+
+    """
+    logging.info("fetching projects migration statuses")
+
+
+def _find_ess_dir(pnum: str, root: str = "/ess",) -> Optional[str]:
+    sub_dir = None
+    for projects_dir in os.listdir(root):
+        if pnum in os.listdir(f"{root}/{projects_dir}"):
+            sub_dir = projects_dir
+            break
+    return None if not sub_dir else f"{root}/{sub_dir}/{pnum}/data/durable"
+
+
+class StorageTemporarilyUnavailableError(Exception):
+    """
+    Raised for backends which cannot be used during migration.
+
+    """
+    pass
+
+
+def find_tenant_storage_path(
+    tenant: str,
+    endpoint_backend: str,
+    opts: tornado.options.OptionParser,
+    root: str = "/ess",
+) -> str:
+    """
+    Either one of these:
+
+        - /tsd/{pnum}/data/durable
+        - /ess/projects0{1|2|3}/{pnum}/data/durable
+
+    Results are cached in a dict stored on options:
+
+    {
+        pnum: {
+            storage_backend: Optional[str] (hnas|migrating|ess),
+            storage_paths: {
+                hnas: str,
+                ess: Optional[str],
+            },
+        }
+    }
+
+    Returns the path which the endpoint_backend should use.
+
+    """
+    cache = opts.tenant_storage_cache.copy()
+    if not cache.get(tenant):
+        cache[tenant] = {
+            "storage_backend": opts.migration_statuses.get(tenant),
+            "storage_paths": {
+                "hnas": f"/tsd/{tenant}/data/durable",
+                "ess": None,
+            }
+        }
+    if (
+        opts.migration_statuses.get(tenant) == "ess"
+        and not cache.get(tenant).get("storage_paths").get("ess")
+    ):
+        cache[tenant]["storage_backend"] = "ess"
+        cache[tenant]["storage_paths"]["ess"] = _find_ess_dir(tenant, root=root)
+    opts.tenant_storage_cache = cache
+    preferred = "ess" if endpoint_backend in opts.prefer_ess else "hnas"
+    path = cache.get(tenant).get("storage_paths").get(preferred)
+    if not path:
+        raise StorageTemporarilyUnavailableError
+    else:
+        return path
 
 
 def call_request_hook(path: str, params: list, as_sudo: bool = True) -> None:


### PR DESCRIPTION
This will disallow import and export of files during project migration. Other backends will not be affected (given correct config).

How? In brief:
* listen to a postgres channel in the IAM DB which notifies when the projects table changes
* load all migration statuses
* on request, check if a project migration is active
* if a backend prefers ESS, such as import and export, then return 503
* once the migration is complete, the project can operate as normal