### PR TITLE
Implement delivering sns files to ESS

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -787,6 +787,11 @@ class GenericFormDataHandler(AuthRequestHandler):
                 f.write(filebody)
                 os.rename(self.path, self.path_part)
                 os.chmod(self.path_part, _RW_RW___)
+            # copy the project's version too
+            if ess_path and self.path_part.startswith("/tsd"):
+                target = self.path_part.replace(f"/tsd/{self.tenant}", ess_path)
+                shutil.copy(self.path_part, target)
+                os.chmod(target, _RW_RW___)
             self.new_paths.append(self.path_part)
             if self.backend == 'sns':
                 subfolder_path = os.path.normpath(tsd_hidden_folder + '/' + filename)
@@ -799,7 +804,7 @@ class GenericFormDataHandler(AuthRequestHandler):
                     if ess_path and subfolder_path.startswith("/tsd"):
                         target = subfolder_path.replace(f"/tsd/{self.tenant}", ess_path)
                         shutil.copy(self.path_part, target)
-                        os.chmod(subfolder_path, _RW_RW___)
+                        os.chmod(target, _RW_RW___)
                 except Exception as e:
                     logging.error(e)
                     logging.error('Could not copy file %s to .tsd folder', self.path_part)

--- a/tsdfileapi/utils.py
+++ b/tsdfileapi/utils.py
@@ -174,7 +174,7 @@ def sns_dir(
             os.makedirs(_path)
             subprocess.call(['chmod', '2770', _path])
             logging.info('Created %s', _path)
-        if opts:
+        if opts and _path.startswith("/tsd"):
             try:
                 ess_path = opts.tenant_storage_cache.get(tenant, {}).get("storage_paths", {}).get("ess")
                 target = _path.replace(f"/tsd/{tenant}/data/durable", ess_path)


### PR DESCRIPTION
This copies data stored on HNAS to ESS, configurable on a per project basis. Delivering to both storage systems allows downstream data processing to transition without having to coordinate this change.