### PR TITLE
Test fixes/improvements and automation

### DIFF
--- a/.github/misc/containers/Dockerfile.test
+++ b/.github/misc/containers/Dockerfile.test
@@ -1,4 +1,5 @@
-FROM docker.io/python:3.9
+ARG PYTHON_VERSION=3
+FROM docker.io/python:${PYTHON_VERSION}
 
 RUN apt-get update
 RUN apt-get install -y libsodium23 libmagic1 sudo

--- a/.github/misc/containers/Dockerfile.test
+++ b/.github/misc/containers/Dockerfile.test
@@ -1,0 +1,14 @@
+FROM docker.io/python:3.9
+
+RUN apt-get update
+RUN apt-get install -y libsodium23 libmagic1 sudo
+
+RUN groupadd p11-member-group
+RUN groupadd p12-member-group
+WORKDIR /file-api
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . ./
+RUN python setup.py install

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -7,10 +7,15 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+      - name: Set container tag to variable
+        run: echo "CONTAINER_TAG=tsd-file-api:${{ github.sha }}-py${{ matrix.python-version }}-r${{ github.run_attempt }}" >> $GITHUB_ENV
       - name: Build test container image
-        run: docker build -t tsd-file-api -f "./.github/misc/containers/Dockerfile.test" .
+        run: docker build --tag "${{ env.CONTAINER_TAG }}" --build-arg PYTHON_VERSION="${{ matrix.python-version }}"  -f "./.github/misc/containers/Dockerfile.test" .
       - name: Run all tsd-file-api tests
-        run: docker run --rm tsd-file-api /bin/sh -c "python tsdfileapi/api.py & sleep 2 && python tsdfileapi/test_file_api.py"
+        run: docker run --rm "${{ env.CONTAINER_TAG }}" /bin/sh -c "python tsdfileapi/api.py & sleep 2 && python tsdfileapi/test_file_api.py"

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -4,12 +4,33 @@ on:
   push:
   pull_request:
 
+env:
+  TSD_FILE_API_DB_NAME: tsd_file_api_db
+  TSD_FILE_API_DB_USER: tsd_file_api_user
+  TSD_FILE_API_DB_PASS: tsd_file_api_pass
+
 jobs:
-  run-tests:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    services:
+      postgres:
+        image: docker.io/postgres:14
+        env:
+          POSTGRES_DB: ${{env.TSD_FILE_API_DB_NAME}}
+          POSTGRES_USER: ${{env.TSD_FILE_API_DB_USER}}
+          POSTGRES_PASSWORD: ${{env.TSD_FILE_API_DB_PASS}}
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -17,5 +38,7 @@ jobs:
         run: echo "CONTAINER_TAG=tsd-file-api:${{ github.sha }}-py${{ matrix.python-version }}-r${{ github.run_attempt }}" >> $GITHUB_ENV
       - name: Build test container image
         run: docker build --tag "${{ env.CONTAINER_TAG }}" --build-arg PYTHON_VERSION="${{ matrix.python-version }}"  -f "./.github/misc/containers/Dockerfile.test" .
-      - name: Run all tsd-file-api tests
+      - name: Run all tsd-file-api tests (SQLite)
         run: docker run --rm "${{ env.CONTAINER_TAG }}" /bin/sh -c "python tsdfileapi/api.py & sleep 2 && python tsdfileapi/test_file_api.py"
+      - name: Run all tsd-file-api tests (PostgreSQL)
+        run: docker run --rm "${{ env.CONTAINER_TAG }}" /bin/sh -c "python tsdfileapi/api.py tsdfileapi/config/config-test-container-postgres.yaml & sleep 2 && python tsdfileapi/test_file_api.py"

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -1,0 +1,16 @@
+name: Run test suite
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Build test container image
+        run: docker build -t tsd-file-api -f "./.github/misc/containers/Dockerfile.test" .
+      - name: Run all tsd-file-api tests
+        run: docker run --rm tsd-file-api /bin/sh -c "python tsdfileapi/api.py & sleep 2 && python tsdfileapi/test_file_api.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ libnacl==1.7.1
 pika==1.1.0
 six==1.15.0
 https://github.com/unioslo/pysquril/archive/refs/tags/v0.2.1.tar.gz#egg=pysquril==0.2.1
+backoff>=2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ termcolor==1.1.0
 libnacl==1.7.1
 pika==1.1.0
 six==1.15.0
-https://github.com/unioslo/pysquril/archive/refs/tags/v0.2.1.tar.gz#egg=pysquril==0.2.1
+https://github.com/unioslo/pysquril/archive/refs/tags/v0.2.2.tar.gz#egg=pysquril==0.2.2
 backoff>=2.2.1

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -666,6 +666,17 @@ class AuthRequestHandler(RequestHandler):
         except Exception as e:
             logging.warning(f"could not update audit log: {e}")
 
+    def additional_log_details(self) -> Dict[str, Any]:
+        """Retrieve additional details for logging.
+
+        Returns:
+            str: details for appending to log output
+        """
+        additional_details = {}
+        if hasattr(self, "requestor"):
+            additional_details["Requestor"] = self.requestor
+        return additional_details
+
 
 class SnsFormDataHandler(AuthRequestHandler):
 
@@ -997,17 +1008,6 @@ class FileRequestHandler(AuthRequestHandler):
             base64.b64decode(headers["Nacl-Key"])
         )
         self.nacl_chunksize = int(headers["Nacl-Chunksize"])
-
-    def additional_log_details(self) -> Dict[str, Any]:
-        """Retrieve additional details for logging.
-
-        Returns:
-            str: details for appending to log output
-        """
-        additional_details = {}
-        if hasattr(self, "requestor"):
-            additional_details["Requestor"] = self.requestor
-        return additional_details
 
     def initialize(self, backend: str, namespace: str, endpoint: str) -> None:
         default_group_logic = {

--- a/tsdfileapi/config/config-test-container-postgres.yaml
+++ b/tsdfileapi/config/config-test-container-postgres.yaml
@@ -1,0 +1,203 @@
+api_user: root
+backends:
+  dbs:
+    apps_tables:
+      db:
+        engine: postgres
+        path:
+        dbconfig:
+          dbname: 'tsd_file_api_db'
+          user: 'tsd_file_api_user'
+          pw: 'tsd_file_api_pass'
+          host: '172.17.0.1'
+      table_structure:
+      mq:
+    survey:
+      db:
+        engine: postgres
+        path:
+        dbconfig:
+          dbname: 'tsd_file_api_db'
+          user: 'tsd_file_api_user'
+          pw: 'tsd_file_api_pass'
+          host: '172.17.0.1'
+      table_structure:
+        - submissions
+        - metadata
+        - attachments
+        - audit
+      mq:
+    publication:
+      db:
+        engine: postgres
+        path:
+        dbconfig:
+          dbname: 'tsd_file_api_db'
+          user: 'tsd_file_api_user'
+          pw: 'tsd_file_api_pass'
+          host: '172.17.0.1'
+      table_structure:
+      mq:
+  disk:
+    apps_files:
+      allow_delete: true
+      allow_export: true
+      allow_info: true
+      allow_list: true
+      export_max_num_list: null
+      export_path: /tmp/pXX
+      export_policy:
+        default:
+          enabled: false
+      group_logic:
+        default_memberships:
+        - pXX-member-group
+        default_url_group: null
+        enabled: false
+      has_posix_ownership: false
+      import_path: /tmp/pXX
+      request_hook:
+        enabled: false
+    files_export:
+      allow_delete: true
+      allow_export: true
+      allow_info: true
+      allow_list: true
+      export_max_num_list: null
+      export_path: /file-api/tsdfileapi/data/tsd/pXX/export
+      export_policy:
+        default:
+          enabled: false
+      group_logic:
+        default_memberships:
+        - pXX-member-group
+        default_url_group: null
+        enabled: false
+      has_posix_ownership: false
+      import_path: /tmp/pXX
+      request_hook:
+        enabled: false
+    files_import:
+      allow_delete: true
+      allow_export: true
+      allow_info: true
+      allow_list: true
+      export_max_num_list: null
+      export_path: /tmp/pXX/import
+      export_policy:
+        default:
+          enabled: false
+      group_logic:
+        default_memberships:
+        - pXX-member-group
+        default_url_group: pXX-member-group
+        enabled: true
+        enforce_membership: true
+        ensure_tenant_in_group_name: true
+        valid_group_regex: p[0-9]+-[a-zA-Z0-9-]+
+      has_posix_ownership: true
+      import_path: /tmp/pXX/import
+      request_hook:
+        enabled: false
+        path: /usr/local/bin/chowner
+        sudo: false
+    form_data:
+      import_path: /tmp/pXX/import
+      request_hook:
+        enabled: false
+        path: false
+        sudo: false
+    publication:
+      allow_delete: true
+      allow_export: true
+      allow_info: true
+      allow_list: true
+      export_max_num_list: null
+      export_path: /tmp/pXX
+      export_policy:
+        default:
+          enabled: false
+      group_logic:
+        default_memberships:
+        - pXX-member-group
+        default_url_group: null
+        enabled: false
+      has_posix_ownership: false
+      import_path: /tmp/pXX
+      request_hook:
+        enabled: false
+    sns:
+      import_path: /tmp/pXX/data/durable/nettskjema-submissions/KEYID/FORMID
+      request_hook:
+        enabled: false
+        path: false
+        sudo: false
+      subfolder_path: /tmp/pXX/data/durable/nettskjema-submissions/.tsd/KEYID/FORMID
+    survey:
+      allow_delete: true
+      allow_export: true
+      allow_info: true
+      allow_list: true
+      export_max_num_list: null
+      export_path: /tmp/pXX/survey
+      export_policy:
+        default:
+          enabled: false
+      group_logic:
+        default_memberships:
+        - pXX-member-group
+        default_url_group: pXX-member-group
+        enabled: false
+        enforce_membership: false
+        ensure_tenant_in_group_name: false
+        valid_group_regex: p[0-9]+-[a-z-]+
+      has_posix_ownership: false
+      import_path: /tmp/pXX/survey
+      request_hook:
+        enabled: false
+create_tenant_dir: true
+data_folder: /file-api/tsdfileapi/data
+debug: true
+default_file_owner: pXX-nobody
+disallowed_start_chars: '~'
+export_chunk_size: 512000
+export_max_num_list: 100
+jwt_secret: null
+jwt_test_secret: jS25aQbePizfTsetg8LbFsNKl1W6wi4nQaBj705ofWA=
+log_level: info
+max_body_size: 5368709120
+nacl_public:
+  private: fTEB1MZz8MskkZHSIM9ypxJc4e45Z8fmLGGXkUrp1hQ=
+  public: mZQEzkyi7bCvmDVfHGsU/7HX1+gT/R3PkSnyDU4OaiY=
+port: 3003
+public_key_id: 264CE5ED60A7548B
+request_log:
+  backends:
+    claims:
+    - name
+    - host
+    - pid
+    files_export:
+      methods:
+      - GET
+      - DELETE
+  db:
+    engine: sqlite
+    path: /tmp/p11
+requestor_claim_name: user
+tenant_claim_name: proj
+tenant_string_pattern: pXX
+test_folder: /file-api/tsdfileapi/tests
+test_formid: '123456'
+test_group: p11-member-group
+test_keyid: 264CE5ED60A7548B
+test_nacl_public:
+  private: fTEB1MZz8MskkZHSIM9ypxJc4e45Z8fmLGGXkUrp1hQ=
+  public: mZQEzkyi7bCvmDVfHGsU/7HX1+gT/R3PkSnyDU4OaiY=
+test_nacl_secret:
+  key: rmsGmiADWiQHcq2n6+QUtTg0oWSxAlmEm4KRcpDWveE=
+test_project: p11
+test_user: p11-testing
+token_check_exp: true
+token_check_tenant: true
+valid_tenant_regex: ^[0-9a-z]+$

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -439,10 +439,11 @@ class TestFileApi(unittest.TestCase):
         )
         # get it back
         resp = requests.get(f"{self.survey}/123456/submissions", headers=headers)
-        data = json.loads(resp.text)
-        self.assertEqual(len(data), 2, "wrong number of submissions")
-        self.assertEqual(data[0].get("key1"), 7)
-        self.assertEqual(data[1].get("key1"), 99)
+        resp_data = json.loads(resp.text)
+        self.assertEqual(data, resp_data)
+        self.assertEqual(len(resp_data), 2, "wrong number of submissions")
+        self.assertEqual(resp_data[0].get("key1"), 7)
+        self.assertEqual(resp_data[1].get("key1"), 99)
         self.assertEqual(resp.status_code, 200)
         # audit functionality
         resp = requests.patch(
@@ -460,6 +461,7 @@ class TestFileApi(unittest.TestCase):
         # that we recorded the change in the audit
         resp = requests.get(f"{self.survey}/123456/audit", headers=headers)
         data = json.loads(resp.text)
+        self.assertTrue(data)
         self.assertEqual(data[-1].get("diff"), {"key1": 5})
         self.assertEqual(data[-1].get("previous").get("key1"), 7)
         self.assertEqual(resp.status_code, 200)
@@ -1661,6 +1663,7 @@ class TestFileApi(unittest.TestCase):
         resp = requests.get(f"{self.apps}/ega/tables/user_data/audit", headers=headers)
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.text)
+        self.assertTrue(data)
         self.assertEqual(data[0].get("diff"), new_version)
 
         # metadata

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -494,14 +494,6 @@ class TestFileApi(unittest.TestCase):
         self.assertTrue("submissions" in data["data"])
         self.assertTrue("attachments" in data["data"])
 
-        ### Make wrong query and get a 400
-        resp = requests.patch(
-            f"{self.survey}/123456/submissions?set=key1&set=key2&where=key2=eq.bla",
-            headers=headers,
-            data=json.dumps({"key1": 5, "key2": 5}),
-        )
-        self.assertEqual(resp.status_code, 400)
-
         # perform some queries
         resp = requests.get(
             f"{self.base_url}/survey/123456/submissions?select=count(*)",

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -720,7 +720,7 @@ class TestFileApi(unittest.TestCase):
         resp = requests.get(
             self.export + "/" + url_escape("blå_fil_3_(v1).txt"), headers=headers
         )
-        self.assertEqual(resp.text, "even more data")
+        self.assertEqual(resp.text, "even more data\n")
         self.assertEqual(resp.status_code, 200)
         resp = requests.head(
             self.export + "/" + url_escape("this is a file"), headers=headers
@@ -729,12 +729,12 @@ class TestFileApi(unittest.TestCase):
         resp = requests.get(
             self.export + "/" + url_escape("this is a file"), headers=headers
         )
-        self.assertEqual(resp.text, "Lol")
+        self.assertEqual(resp.text, "Lol\n")
         self.assertEqual(resp.status_code, 200)
         resp = requests.get(
             self.export + "/" + url_escape("this+is+another+file"), headers=headers
         )
-        self.assertEqual(resp.text, "epiphenomena")
+        self.assertEqual(resp.text, "epiphenomena\n")
         self.assertEqual(resp.status_code, 200)
 
     # resumable uploads

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -2338,7 +2338,9 @@ def main() -> None:
         suite.addTest(TestFileApi(test))
     runner = unittest.TextTestRunner()
     #    runner = unittest.TextTestRunner(verbosity=3, failfast=True)
-    runner.run(suite)
+    result = runner.run(suite)
+    # in Python int(True) is 1, int(False) is 0
+    sys.exit(not result.wasSuccessful())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We should version bump pysquril before merging this so we can pin requirements on a proper version tag. <- done in c6349f843a205bd7dd28075df3e2a7710517ff56

Follow-ups addressed before marking ready for review:
* Testing with several versions of Python
  * Variable container `FROM` base image directive and matrix strategy added in ddc596a2eeee9931b94715838e4566286fcc76d3
* Testing both SQLite and Postgres databases
  * Implemented in f0d61fc2e268bf9a7629d801859c7bf835df4470
* Investigate why `test_mtime_functionality()` will occasionally fail
  * Seems like race condition, ~addressed by 830118b9d2b65506ca0eb7a7c5b07c379854ea1f if so~
    * ~Scratch that, [still happening](https://github.com/haatveit/tsd-file-api/actions/runs/4164104164/jobs/7205303931#step:6:648)~
    * Should be fixed in 7a0093d06aeeb68c47c2eabe51c758b8c675b024 if it is indeed a race condition on file access