### PR TITLE
Easier (containerized) local development

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -44,15 +44,19 @@ jobs:
           docker run --rm
           -v $PWD:/file-api:ro
           --name tsd-file-api-sqlite
+          --health-cmd "curl --fail http://127.0.0.1:3003/v1/all/config || exit 1"
+          --health-interval=2s
           "${{ env.CONTAINER_TAG }}" &
-          sleep 10 &&
+          until [ "$(docker inspect -f {{.State.Health.Status}} tsd-file-api-sqlite)" == "healthy" ]; do sleep 0.1; done &&
           docker exec tsd-file-api-sqlite python tsdfileapi/test_file_api.py
       - name: Start tsd-file-api container and run tests (PostgreSQL backend)
         run: >
           docker run --rm
           -v $PWD:/file-api:ro
           --name tsd-file-api-postgres
+          --health-cmd "curl --fail http://127.0.0.1:3003/v1/all/config || exit 1"
+          --health-interval=2s
           "${{ env.CONTAINER_TAG }}"
           tsdfileapi/config/config-test-container-postgres.yaml &
-          sleep 10 &&
+          until [ "$(docker inspect -f {{.State.Health.Status}} tsd-file-api-postgres)" == "healthy" ]; do sleep 0.1; done &&
           docker exec tsd-file-api-postgres python tsdfileapi/test_file_api.py

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -13,6 +13,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 

--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -38,8 +38,21 @@ jobs:
       - name: Set container tag to variable
         run: echo "CONTAINER_TAG=tsd-file-api:${{ github.sha }}-py${{ matrix.python-version }}-r${{ github.run_attempt }}" >> $GITHUB_ENV
       - name: Build test container image
-        run: docker build --tag "${{ env.CONTAINER_TAG }}" --build-arg PYTHON_VERSION="${{ matrix.python-version }}"  -f "./containers/Dockerfile.test" .
-      - name: Run all tsd-file-api tests (SQLite)
-        run: docker run --rm "${{ env.CONTAINER_TAG }}" /bin/sh -c "tsd-file-api & sleep 2 && python tsdfileapi/test_file_api.py"
-      - name: Run all tsd-file-api tests (PostgreSQL)
-        run: docker run --rm "${{ env.CONTAINER_TAG }}" /bin/sh -c "tsd-file-api tsdfileapi/config/config-test-container-postgres.yaml & sleep 2 && python tsdfileapi/test_file_api.py"
+        run: docker build --tag "${{ env.CONTAINER_TAG }}" --build-arg PYTHON_VERSION="${{ matrix.python-version }}"  -f "./containers/test/Dockerfile" .
+      - name: Start tsd-file-api container and run tests (SQLite backend)
+        run: >
+          docker run --rm
+          -v $PWD:/file-api:ro
+          --name tsd-file-api-sqlite
+          "${{ env.CONTAINER_TAG }}" &
+          sleep 10 &&
+          docker exec tsd-file-api-sqlite python tsdfileapi/test_file_api.py
+      - name: Start tsd-file-api container and run tests (PostgreSQL backend)
+        run: >
+          docker run --rm
+          -v $PWD:/file-api:ro
+          --name tsd-file-api-postgres
+          "${{ env.CONTAINER_TAG }}"
+          tsdfileapi/config/config-test-container-postgres.yaml &
+          sleep 10 &&
+          docker exec tsd-file-api-postgres python tsdfileapi/test_file_api.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+PROJECT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+CONTAINER_ENGINE ?= podman
+BUILD_OPTS ?=
+
+MOUNTFLAGS = ro
+ifeq ($(UNAME_S),Linux)
+	MOUNTFLAGS += ,z
+endif
+
+.PHONY: build_test_container run tests
+
+build_test_container: # Build the test/development container image
+	$(CONTAINER_ENGINE) build $(BUILD_OPTS) --file $(PROJECT_DIR)/containers/test/Dockerfile --tag tsd-file-api-test $(PROJECT_DIR)
+
+run: build_test_container # Run development server
+	$(CONTAINER_ENGINE) run --rm --replace --name tsd-file-api-test --publish 127.0.0.1:3003:3003 --volume $(PROJECT_DIR):/file-api:$(MOUNTFLAGS) tsd-file-api-test
+
+tests: # Run tests against the development server
+	$(CONTAINER_ENGINE) exec tsd-file-api-test python tsdfileapi/test_file_api.py

--- a/containers/test/Dockerfile
+++ b/containers/test/Dockerfile
@@ -5,11 +5,17 @@ RUN apt-get update
 RUN apt-get install -y libsodium23 libmagic1 sudo
 RUN pip install poetry
 RUN poetry config virtualenvs.create false
-RUN poetry self add "poetry-dynamic-versioning[plugin]"
 
 RUN groupadd p11-member-group
 RUN groupadd p12-member-group
+
+COPY containers/test/entrypoint.sh ./
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+EXPOSE 3003
+VOLUME [ "/file-api" ]
+
 WORKDIR /file-api
 
-COPY . ./
+COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-interaction

--- a/containers/test/entrypoint.sh
+++ b/containers/test/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+CONFIG_FILE="$1"
+
+/usr/local/bin/poetry install
+
+if [ -z "$CONFIG_FILE" ]; then
+    exec /usr/local/bin/tsd-file-api
+else
+    exec /usr/local/bin/tsd-file-api "$CONFIG_FILE"
+fi


### PR DESCRIPTION
This PR modifies the test container to only install the project dependencies, and instead rely on bind mounting in the repository. This makes it much easier for use in local development.

* The test workflow has been adapted to work with the container changes.
* A Makefile for running a (containerized) local development file API instance and executing tests against it is included.

There will be a follow-up PR with relevant documentation additions/changes if accepted.