### PR TITLE
Add workflow for creating GitHub release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Create GitHub release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip wheel build
+      - name: Build the package
+        run: python -m build
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/**
+          generate_release_notes: true


### PR DESCRIPTION
Adding the workflow we use for tsd-api-client, <https://github.com/unioslo/tsd-api-client/blob/master/.github/workflows/release.yaml>.

Automatically creates a new GH release with generated release notes on `v*` tagging of a commit.