### PR TITLE
fix: log warning on already finalised upload

### DIFF
--- a/tsdfileapi/resumables.py
+++ b/tsdfileapi/resumables.py
@@ -644,7 +644,12 @@ class SerialResumable(AbstractResumable):
                 os.rename(out, final)
             except FileNotFoundError as e:
                 logger.error(e)
-                raise ResumableNotFoundError
+                if not os.path.exists(out) and os.path.exists(final):
+                    logger.warning(
+                        f"resumable upload '{upload_id}' has already been moved to its final path '{final}'"
+                    )
+                else:
+                    raise ResumableNotFoundError
             try:
                 shutil.rmtree(
                     chunks_dir


### PR DESCRIPTION
Instead of finalise() failing out in this corner case of operation previously
having been interrupted after moving data to its final location but before
reporting success, the function will now log a warning and proceed with cleanup.