### PR TITLE
Build fix for RHEL7 RPMs

### DIFF
--- a/.github/workflows/build-rpm-el7.yaml
+++ b/.github/workflows/build-rpm-el7.yaml
@@ -43,9 +43,11 @@ jobs:
           sleep 5
           docker cp "$CONTAINER_ID":/file-api/rpm ./
           docker rm "$CONTAINER_ID"
+      - name: Get artifact filename
+        run: echo "ARTIFACT_NAME=$(ls rpm/)" >> $GITHUB_ENV
       - name: Upload the extracted RPM as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: RPM-el7
+          name: "${{ env.ARTIFACT_NAME }}"
           path: rpm
           if-no-files-found: error

--- a/containers/rpm-el7/Dockerfile
+++ b/containers/rpm-el7/Dockerfile
@@ -21,8 +21,9 @@ RUN yum -y install \
 # ERROR:  Error installing fpm:
 #       ffi requires Ruby version >= 2.3.
 RUN yum -y install centos-release-scl-rh centos-release-scl
-RUN yum --enablerepo=centos-sclo-rh -y install rh-ruby23 rh-ruby23-ruby-devel
-RUN source /opt/rh/rh-ruby23/enable && gem install --no-ri --no-rdoc fpm
+RUN yum --enablerepo=centos-sclo-rh -y install rh-ruby30 rh-ruby30-ruby-devel
+RUN source /opt/rh/rh-ruby30/enable && \
+    gem install --no-document fpm
 
 # install Python 3.8 from SCL
 RUN yum install -y rh-python38 rh-python38-python-devel
@@ -56,7 +57,7 @@ RUN poetry export --without-hashes --format requirements.txt --output requiremen
 RUN echo "." >> requirements.txt
 
 # build RPM of the dependencies virtual environment
-RUN source /opt/rh/rh-ruby23/enable &&\
+RUN source /opt/rh/rh-ruby30/enable &&\
     source /opt/rh/rh-python38/enable &&\
     mkdir -p /file-api/rpm && \
     fpm --verbose -s virtualenv -p /file-api/rpm \

--- a/containers/rpm-el7/Dockerfile
+++ b/containers/rpm-el7/Dockerfile
@@ -62,5 +62,6 @@ RUN source /opt/rh/rh-ruby30/enable &&\
     mkdir -p /file-api/rpm && \
     fpm --verbose -s virtualenv -p /file-api/rpm \
     -t rpm --name tsd-file-api --version $(poetry version --short --no-ansi) \
+    --rpm-dist $(rpm --eval "%dist" | sed "s/\.//") \
     --depends libsodium --depends sudo \
     --prefix /opt/tsd-file-api requirements.txt

--- a/containers/rpm-el7/Dockerfile
+++ b/containers/rpm-el7/Dockerfile
@@ -23,7 +23,7 @@ RUN yum -y install \
 RUN yum -y install centos-release-scl-rh centos-release-scl
 RUN yum --enablerepo=centos-sclo-rh -y install rh-ruby30 rh-ruby30-ruby-devel
 RUN source /opt/rh/rh-ruby30/enable && \
-    gem install --no-document fpm
+    gem install --no-document fpm --version 1.15.1
 
 # install Python 3.8 from SCL
 RUN yum install -y rh-python38 rh-python38-python-devel


### PR DESCRIPTION
fpm's dependency REXML dropped support for Ruby <2.5 in version 3.2.6
which was released on 2023-07-27. This made RHEL7 RPM building fail.

As fpm has supported Ruby 3.0 since version 1.13.0 released 2021-06-19,
I thought that we might as well upgrade Ruby instead of pinning an old
REXML version.

The gem install parameter for disabling documentation building has
changed in Ruby 3, update our usage accordingly.