### PR TITLE
fix(api): set survey endpoints to "survey"

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -2803,12 +2803,12 @@ class Backends:
             (
                 "/v1/(.*)/survey/([a-zA-Z_0-9]+/attachments.*)",
                 FileRequestHandler,
-                dict(backend="survey", namespace="survey", endpoint=None),
+                dict(backend="survey", namespace="survey", endpoint="survey"),
             ),
             (
                 "/v1/(.*)/survey/([a-zA-Z_0-9]+/backup.*)",
                 FileRequestHandler,
-                dict(backend="survey", namespace="survey", endpoint=None),
+                dict(backend="survey", namespace="survey", endpoint="survey"),
             ),
             ("/v1/(.*)/survey/resumables", ResumablesHandler, dict(backend="survey")),
             (


### PR DESCRIPTION
This fixes the incorrect final component of routing keys in the AMQP
messages emitted by these endpoints, resolving #181.