### PR TITLE
Use fewer connections for IAM DB

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -165,14 +165,16 @@ def set_config() -> None:
             "accept_calls_per_event_loop"
         ]
     options.logging = _config.get("log_level", "info")
-    try:  # limit size to 1
+    try:
         projects_pool = postgres_init(
             {
                 "user": _config.get("iamdb_user"),
                 "pw": _config.get("iamdb_pw"),
                 "host": _config.get("iamdb_host"),
                 "dbname": _config.get("iamdb_dbname"),
-            }
+            },
+            min_conn=1,
+            max_conn=2,
         )
     except Exception as e:
         projects_pool = None

--- a/tsdfileapi/db.py
+++ b/tsdfileapi/db.py
@@ -101,9 +101,9 @@ def sqlite_init(
     return engine
 
 
-def postgres_init(dbconfig: dict) -> psycopg2.pool.SimpleConnectionPool:
-    min_conn = 2
-    max_conn = 4
+def postgres_init(
+    dbconfig: dict, min_conn: int = 2, max_conn: int = 4
+) -> psycopg2.pool.SimpleConnectionPool:
     dsn = f"dbname={dbconfig['dbname']} user={dbconfig['user']} password={dbconfig['pw']} host={dbconfig['host']}"
     pool = psycopg2.pool.SimpleConnectionPool(min_conn, max_conn, dsn)
     return pool


### PR DESCRIPTION
We only need two: one for listening on the channel, and another for fetching data. This also reduces memory usage on the DB server, especially when running many processes.