### PR TITLE
Less inclusive regex for routing to the audit log, health check and test token endpoints

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -2760,7 +2760,7 @@ class Backends:
             ("/v1/all/config", ConfigHandler),
         ],
         "token": [
-            ("/v1/(.+)/token", TestTokenHandler),
+            ("/v1/([^/]+)/token", TestTokenHandler),
         ],
     }
 

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -2747,7 +2747,7 @@ class TestTokenHandler(RequestHandler):
 class Backends:
     default_routes = {
         "health": [
-            ("/v1/(.*)/files/health", HealthCheckHandler),
+            ("/v1/([^/]+)/files/health", HealthCheckHandler),
         ],
         "runtime_configuration": [
             ("/v1/admin.*", RunTimeConfigurationHandler),

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -2753,8 +2753,8 @@ class Backends:
             ("/v1/admin.*", RunTimeConfigurationHandler),
         ],
         "audit_log_viewer": [
-            ("/v1/(.+)/logs", AuditLogViewerHandler),
-            ("/v1/(.+)/logs/(.+)", AuditLogViewerHandler),
+            ("/v1/([^/]+)/logs", AuditLogViewerHandler),
+            ("/v1/([^/]+)/logs/(.+)", AuditLogViewerHandler),
         ],
         "config": [
             ("/v1/all/config", ConfigHandler),


### PR DESCRIPTION
This updated regex rule for routing to `AuditLogViewerHandler` now only permits one tenant identifier before `/logs` by not including `/` in the matched characters.