### PR TITLE
Limit GHA workflow pull_request triggers to forks

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -10,6 +10,7 @@ on:
       - pyproject.toml
       - poetry.lock
   pull_request:
+    types: [opened, reopened, synchronize]
     paths:
       - .github/workflows/audit.yaml
       - pyproject.toml
@@ -20,6 +21,7 @@ on:
 jobs:
   export-requirements:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner)
     steps:
       - uses: actions/checkout@v3
       - name: Install Poetry

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,9 +3,11 @@ name: pre-commit
 on:
   push:
   pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   pre-commit:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ on:
       - poetry.lock
       - tsdfileapi/**
   pull_request:
+    types: [opened, reopened, synchronize]
     paths:
       - .github/workflows/tests.yaml
       - pyproject.toml
@@ -22,6 +23,7 @@ env:
 
 jobs:
   tests:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Since we're already running these jobs on `push` to all branches in the repo, it's redundant also triggering on pull_request events.