### PR TITLE
Lock fpm and its dependencies

### DIFF
--- a/containers/rpm/Dockerfile
+++ b/containers/rpm/Dockerfile
@@ -34,7 +34,9 @@ RUN source /etc/os-release && \
 
 # Install the fpm packaging utility
 # https://fpm.readthedocs.io/en/latest/index.html
-RUN gem install --no-document fpm --version 1.15.1
+RUN gem install bundler -v 1.17.2
+COPY containers/rpm/Gemfile* ./
+RUN bundle install --system
 
 # Install virtualenv with Python 3
 RUN python3 -m pip install virtualenv virtualenv-tools3

--- a/containers/rpm/Gemfile
+++ b/containers/rpm/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'fpm', '1.15.1'
+gem 'dotenv', '<3'

--- a/containers/rpm/Gemfile.lock
+++ b/containers/rpm/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arr-pm (0.0.12)
+    backports (3.24.1)
+    cabin (0.9.0)
+    clamp (1.0.1)
+    dotenv (2.8.1)
+    fpm (1.15.1)
+      arr-pm (~> 0.0.11)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      clamp (~> 1.0.0)
+      pleaserun (~> 0.0.29)
+      rexml
+      stud
+    insist (1.0.0)
+    mustache (0.99.8)
+    pleaserun (0.0.32)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    rexml (3.2.6)
+    stud (0.0.23)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dotenv (< 3)
+  fpm (= 1.15.1)
+
+BUNDLED WITH
+   1.17.2


### PR DESCRIPTION
Add a Gemfile with locked dependencies and install a specific bundler, to avoid future incompatibilities with RHEL-provided Ruby packages.

This PR resolves #211.