### PR TITLE
Stop skipping scheduled dependency audits

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   export-requirements:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner)
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner)
     steps:
       - uses: actions/checkout@v3
       - name: Install Poetry


### PR DESCRIPTION
This PR rewrites the job conditional to be more inclusive. The previous rule had the unintended consequence of skipping all scheduled runs.