### PR TITLE
ci(tests): update Poetry 1.3.2 -> 1.8.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ env:
   TSD_FILE_API_DB_NAME: tsd_file_api_db
   TSD_FILE_API_DB_USER: tsd_file_api_user
   TSD_FILE_API_DB_PASS: tsd_file_api_pass
-  POETRY_VERSION: "1.3.2"
+  POETRY_VERSION: "1.8.3"
 
 jobs:
   tests:

--- a/containers/test/Dockerfile
+++ b/containers/test/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/python:${PYTHON_VERSION}
 
 RUN apt-get update
 RUN apt-get install -y libsodium23 libmagic1 sudo libpq-dev
-ARG POETRY_VERSION="1.3.2"
+ARG POETRY_VERSION="1.8.3"
 RUN pip install poetry==${POETRY_VERSION}
 RUN poetry config virtualenvs.create false
 


### PR DESCRIPTION
This resolves CI failures on Python 3.12 due to the removal of distutils. The issue that prompted pinning of 1.3.2 (https://github.com/unioslo/tsd-file-api/pull/196) seems to have been resolved at this point.