### PR TITLE
ci(rpm): switch to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Get artifact filename
         run: echo "ARTIFACT_NAME=$(ls rpm/)" >> $GITHUB_ENV
       - name: Upload the extracted RPM as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.ARTIFACT_NAME }}"
           path: rpm


### PR DESCRIPTION
Just switching from the deprecated `actions/upload-artifact@v3` to `actions/upload-artifact@v4` seemed to be enough for our usage of this action: <https://github.com/unioslo/tsd-file-api/actions/runs/13265657834>.