### PR TITLE
Disable logging of health check requests

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -2638,6 +2638,10 @@ class HealthCheckHandler(RequestHandler):
         self.set_status(HTTPStatus.OK.value)
         self.write({"message": "healthy"})
 
+    def _log(self) -> None:
+        # disable logging for health check requests
+        pass
+
 
 class NaclKeyHander(RequestHandler):
     def get(self, tenant: str) -> None:


### PR DESCRIPTION
Since this endpoint will be probed very frequently in k8s environments, it makes for a lot of noise in log output if each hit is going to emit a log line.

This commit disables logging in the `HealthCheckHandler`, which I think is a small loss considering it'll only ever respond in exactly the same way as long as the API is running. If we implement a more complex health check at a later point in time, I think it would make sense to come back to this and ensure that we log non-good responses, but for now I don't think this needs to be configurable.

This PR resolves #272.