### PR TITLE
Fix a type error with a call to `join`

### DIFF
--- a/tsdfileapi/exc.py
+++ b/tsdfileapi/exc.py
@@ -199,7 +199,7 @@ def error_for_exception(exc: Exception, details: str = "") -> Error:
         code = HTTPStatus.INSUFFICIENT_STORAGE
         status = code.value
         reason = "Project has run out of disk quota"
-        message = ", ".join([ code.phrase, reason, details ])
+        message = ", ".join([code.phrase, reason, details])
         message = generate_message([code.phrase, reason, details])
         headers = {}
     else:

--- a/tsdfileapi/exc.py
+++ b/tsdfileapi/exc.py
@@ -199,7 +199,6 @@ def error_for_exception(exc: Exception, details: str = "") -> Error:
         code = HTTPStatus.INSUFFICIENT_STORAGE
         status = code.value
         reason = "Project has run out of disk quota"
-        message = ", ".join([code.phrase, reason, details])
         message = generate_message([code.phrase, reason, details])
         headers = {}
     else:

--- a/tsdfileapi/exc.py
+++ b/tsdfileapi/exc.py
@@ -199,7 +199,7 @@ def error_for_exception(exc: Exception, details: str = "") -> Error:
         code = HTTPStatus.INSUFFICIENT_STORAGE
         status = code.value
         reason = "Project has run out of disk quota"
-        message = ", ".join(code.phrase, reason, details)
+        message = ", ".join([ code.phrase, reason, details ])
         message = generate_message([code.phrase, reason, details])
         headers = {}
     else:


### PR DESCRIPTION
Hasn't worked since [last re-factoring](https://github.com/unioslo/tsd-file-api/commit/ef8f0534e3c85e6f123825f2b660be3f55423fa6#diff-5f4fdbe84944024de397f94ea3e97c650b17ab2f9a81837032826f98d2915f95R163) because `join` accepts a single argument (an iterable), not 3.

Fixes https://github.com/unioslo/tsd-file-api/issues/275.