### PR TITLE
ensure aggregation functions work on audit logs

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -2732,7 +2732,7 @@ class AuditLogViewerHandler(AuthRequestHandler):
                 for row in db.table_select(table_name, query):
                     if not first:
                         self.write(",")
-                    self.write(row)
+                    self.write(json.dumps(row))
                     self.flush()
                     first = False
                 self.write("]")

--- a/tsdfileapi/test_file_api.py
+++ b/tsdfileapi/test_file_api.py
@@ -2710,6 +2710,11 @@ class TestFileApi(unittest.TestCase):
         resp = requests.get(f"{self.logs}/apps", headers=headers)
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(isinstance(json.loads(resp.text).get("apps"), list))
+        # and that aggregations work
+        resp = requests.get(
+            f"{self.logs}/files_export?select=count(1)", headers=headers
+        )
+        self.assertEqual(resp.status_code, 200)
 
     def test_find_tenant_storage_path(self) -> None:
         td = tempfile.TemporaryDirectory()


### PR DESCRIPTION
The result of an aggregate query such as `select=count(*)` is a list, and tornado refuses to `self.write` lists that are not serialised. This fixes that.