### PR TITLE
feat: add parsing of proxy headers

### DIFF
--- a/tsdfileapi/utils.py
+++ b/tsdfileapi/utils.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+from ipaddress import ip_network
 from typing import Optional
 from typing import Union
 
@@ -243,3 +244,24 @@ def any_path_islink(
             )
         path = path.parent
     return False
+
+
+def cidr_to_set(ip: str) -> set:
+    """Converts a CIDR to a set of IP addresses."""
+    return {str(x) for x in ip_network(ip)}
+
+
+def trusted_proxies_to_trusted_downstream(
+    trusted_proxies: list = None,
+) -> Optional[list]:
+    """Convert our trusted_proxies (CIDR supported) format to a list of IP addresses.
+
+    Tornado expects a list of IP addresses, so we must expand CIDR network
+    ranges to lists of IP addresses that it can support.
+    """
+    if not trusted_proxies:
+        return None
+    trusted_downstream = set()
+    for proxy in trusted_proxies:
+        trusted_downstream = trusted_downstream | cidr_to_set(proxy)
+    return list(trusted_downstream)


### PR DESCRIPTION
This commit adds the following new configuration options:
- parse_proxy_headers (bool)
- trusted_proxies (list)

parse_proxy_headers controls whether or not proxy headers will be parsed. trusted_proxies is a list of hosts to trust when parsing the X-Forwarded-For header, which can be either IP addresses or CIDR format ranges.

This feature leverages tornado.httpserver.HTTPServer's built-in support for proxy headers, which are disabled by default. When enabled it makes Tornado automatically parse values in request headers X-Real-Ip/X-Forwarded-For and X-Scheme/X-Forwarded-Proto.
See https://www.tornadoweb.org/en/stable/httpserver.html for details.

Note that when parse_proxy_headers is enabled, clients will be able to spoof their connecting IP address without a properly configured reverse proxy in the middle. Additionally, trusted_proxies are evaluated by Tornado in the parsing of X-Forwarded-For *only*, and not for X-Real-Ip (which takes precedence) or the scheme headers.