### PR TITLE
Fix resumable download negotiation

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1802,6 +1802,7 @@ class FileRequestHandler(AuthRequestHandler):
                 encrypt_data = True
             self.set_header("Content-Type", mime_type)
             self.set_header("Modified-Time", str(mtime))
+            self.set_header("Accept-Ranges", "bytes")
             if "Range" not in self.request.headers:
                 self.set_header("Content-Length", size)
                 self.flush()


### PR DESCRIPTION
By HTTP, a server opts in to negotiating `Range` based resumption of previously downloaded content, by advertising support using the `Accept-Ranges` header. Curiously, this was in place for `HEAD` requests in `FileRequestHandler`, but not for `GET` -- this commit adds setting of the header for the latter.