### PR TITLE
Use `logger.exception` instead of `logger.error` in an `except` block…

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -921,7 +921,7 @@ class ResumablesHandler(AuthRequestHandler):
             self.write({"message": "not found"})
         except Exception as e:
             error = error_for_exception(e)
-            logger.error(error.message)
+            logger.exception(error.message)
             for name, value in error.headers.items():
                 self.set_header(name, value)
             self.set_status(error.status, reason=error.reason)


### PR DESCRIPTION
… to aid troubleshooting

The latter doesn't print the stack and thus makes troubleshooting harder.

I suppose that longer-term, following [Python's "easier to ask forgiveness than permission" (EAFP)](https://docs.python.org/3/glossary.html#term-EAFP) as "best-practice" (see also PEP 463), which favours using `except` block for dealing even with more "benign" conditions such as invalid list indices, the stack trace _may_ prove to be a case of excessive verbosity in the logs -- if the error always boils down to one easily understood condition. But then -- since the `except` block is big enough that it can catch a lot of things we haven't even seen before -- a case can be made to _retain_ `logger.exception` so we never have to look for clues in the blind should it ever get there for _different_ reason than the perfectly apparent. Regardless, the latter issue, when tracked down to a particular section of code where it originates, can be fixed by doing an explicit check to avoid raising the `KeyError` (index out of bounds), but that would be going against the EAFP practice in favour of [the "look before you leap" (LBYL) counterpart](https://docs.python.org/3/glossary.html#term-LBYL).

What I am trying to get at is that we retain `logger.exception` regardless, since the `except` block appears to cast a "wide net".

P.S. Sorry for the insanely long auto-generated branch name, good news is it's short-lived :B