### PR TITLE
A unit of development work, centered around off-loading of processing

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1293,20 +1293,14 @@ class FileRequestHandler(AuthRequestHandler):
                     self.data_buffer = self.NaclDataBuffer(
                         self.nacl_chunksize, self.nacl_nonce, self.nacl_key
                     )
-                    self.target_file = open(self.path, filemode, buffering=0)
-                    os.chmod(self.path, _RW______)
                 else:
                     self.data_buffer = self.DataBuffer(
                         options.tenant_storage_write_buffer_size
                     )
-                    if self.request.method != "PATCH":
-                        self.target_file = open(self.path, filemode, buffering=0)
-                        os.chmod(self.path, _RW______)
-                    elif self.request.method == "PATCH":
-                        if not self.completed_resumable_file:
-                            self.target_file = self.res.open_file(
-                                self.path, mode=filemode, buffering=0
-                            )
+
+                if self.request.method != "PATCH" or not self.completed_resumable_file:
+                    self.target_file = open(self.path, filemode, buffering=0)
+                    os.chmod(self.path, _RW______)
 
                 if self.request.method == "PATCH":
                     self.store_processed_data = self.store_processed_data_with_resumable

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1331,19 +1331,11 @@ class FileRequestHandler(AuthRequestHandler):
                         self.res.add_chunk(self.target_file, decrypted)
                     else:
                         self.target_file.write(decrypted)
-        except Exception:
-            logger.exception(
-                "something went wrong with stream processing"
-                + (
-                    (" have to close file '%s'" % self.target_file.name)
-                    if self.target_file
-                    else ""
-                )
-            )
+        except:
             if self.target_file:
                 self.target_file.close()
             os.rename(self.path, self.path_part)
-            self.send_error("something went wrong")
+            raise
 
     def put(self, tenant: str, uri_filename: str = None) -> None:
         if not self.custom_content_type:

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1374,7 +1374,7 @@ class FileRequestHandler(AuthRequestHandler):
 
         def __call__(self, data: bytes):
             """
-            Add data to the buffer, iff there's enough data accumulated in the buffer to decrypt a block, remove one block worth of it from the buffer, decrypt the block and yield it.
+            Add data to the buffer and while there's enough data accumulated in the buffer to decrypt a block remove that much worth of data from the buffer, decrypt it and yield it.
             """
             self._buffer += data
             while len(self._buffer) >= self._threshold:

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1309,17 +1309,17 @@ class FileRequestHandler(AuthRequestHandler):
 
     @RequestHandler.run_in_request_processing_context  # For reasons, Tornado evidently runs `data_received` in a _distinct_ context (different from the one we load in `prepare`), so we "force" ours (to retain request ID correlation, among other things)
     @gen.coroutine
-    def data_received(self, chunk: bytes) -> Optional[Awaitable[None]]:
+    def data_received(self, data: bytes) -> Optional[Awaitable[None]]:
         if __debug__ and hasattr(self, "received_data_length"):
-            self.received_data_length += len(chunk)
+            self.received_data_length += len(data)
         try:
             if not self.custom_content_type:
                 if self.request.method == "PATCH":
-                    self.res.add_chunk(self.target_file, chunk)
+                    self.res.add_chunk(self.target_file, data)
                 else:
-                    self.target_file.write(chunk)
+                    self.target_file.write(data)
             elif self.custom_content_type == "application/octet-stream+nacl":
-                self.nacl_stream_buffer += chunk
+                self.nacl_stream_buffer += data
                 while len(self.nacl_stream_buffer) >= self.nacl_chunksize:
                     target_content = self.nacl_stream_buffer[: self.nacl_chunksize]
                     remainder = self.nacl_stream_buffer[self.nacl_chunksize :]

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -173,6 +173,10 @@ def set_config() -> None:
     define("parse_proxy_headers", _config.get("parse_proxy_headers", False))
     define("trusted_proxies", _config.get("trusted_proxies", None))
     define("max_workers", _config.get("max_workers", 1))
+    define(
+        "tenant_storage_write_buffer_size",
+        _config.get("tenant_storage_write_buffer_size", 2**24),
+    )
 
 
 set_config()
@@ -999,8 +1003,6 @@ class ResumablesHandler(AuthRequestHandler):
 
 @stream_request_body
 class FileRequestHandler(AuthRequestHandler):
-    data_received_file_write_threshold = 2**24  # 16MiB
-
     def initialize(self, backend: str, namespace: str, endpoint: str) -> None:
         default_group_logic = {
             "enabled": False,
@@ -1295,7 +1297,7 @@ class FileRequestHandler(AuthRequestHandler):
                     os.chmod(self.path, _RW______)
                 else:
                     self.data_buffer = self.DataBuffer(
-                        self.data_received_file_write_threshold
+                        options.tenant_storage_write_buffer_size
                     )
                     if self.request.method != "PATCH":
                         self.target_file = open(self.path, filemode, buffering=0)

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -706,7 +706,6 @@ class AuthRequestHandler(RequestHandler):
         if not headers.get("Nacl-Chunksize"):
             raise ClientError("Missing Nacl-Chunksize header - cannot decrypt data")
         self.custom_content_type = headers["Content-Type"]
-        self.nacl_stream_buffer = b""
         self.nacl_nonce = options.sealed_box.decrypt(
             base64.b64decode(headers["Nacl-Nonce"])
         )
@@ -1000,6 +999,8 @@ class ResumablesHandler(AuthRequestHandler):
 
 @stream_request_body
 class FileRequestHandler(AuthRequestHandler):
+    data_received_file_write_threshold = 2**24  # 16MiB
+
     def initialize(self, backend: str, namespace: str, endpoint: str) -> None:
         default_group_logic = {
             "enabled": False,
@@ -1287,15 +1288,27 @@ class FileRequestHandler(AuthRequestHandler):
 
                 if content_type == "application/octet-stream+nacl":
                     self.decrypt_nacl_headers(self.request.headers)
-                    self.target_file = open(self.path, filemode)
+                    self.data_buffer = self.NaclDataBuffer(
+                        self.nacl_chunksize, self.nacl_nonce, self.nacl_key
+                    )
+                    self.target_file = open(self.path, filemode, buffering=0)
                     os.chmod(self.path, _RW______)
                 else:
+                    self.data_buffer = self.DataBuffer(
+                        self.data_received_file_write_threshold
+                    )
                     if self.request.method != "PATCH":
-                        self.target_file = open(self.path, filemode)
+                        self.target_file = open(self.path, filemode, buffering=0)
                         os.chmod(self.path, _RW______)
                     elif self.request.method == "PATCH":
                         if not self.completed_resumable_file:
-                            self.target_file = self.res.open_file(self.path, filemode)
+                            self.target_file = self.res.open_file(
+                                self.path, mode=filemode, buffering=0
+                            )
+
+                if self.request.method == "PATCH":
+                    self.store_processed_data = self.store_processed_data_with_resumable
+
         except ResumableIncorrectChunkOrderError:
             self.set_status(HTTPStatus.BAD_REQUEST.value)
             self.finish({"message": "chunk_order_incorrect"})
@@ -1313,56 +1326,80 @@ class FileRequestHandler(AuthRequestHandler):
         if __debug__ and hasattr(self, "received_data_length"):
             self.received_data_length += len(data)
         try:
-            if not self.custom_content_type:
-                if self.request.method == "PATCH":
-                    self.res.add_chunk(self.target_file, data)
-                else:
-                    self.target_file.write(data)
-            elif self.custom_content_type == "application/octet-stream+nacl":
-                self.nacl_stream_buffer += data
-                while len(self.nacl_stream_buffer) >= self.nacl_chunksize:
-                    target_content = self.nacl_stream_buffer[: self.nacl_chunksize]
-                    remainder = self.nacl_stream_buffer[self.nacl_chunksize :]
-                    self.nacl_stream_buffer = remainder
-                    decrypted = libnacl.crypto_stream_xor(
-                        target_content, self.nacl_nonce, self.nacl_key
-                    )
-                    if self.request.method == "PATCH":
-                        self.res.add_chunk(self.target_file, decrypted)
-                    else:
-                        self.target_file.write(decrypted)
+            for processed in self.data_buffer(data):
+                self.store_processed_data(processed)
         except:
             if self.target_file:
                 self.target_file.close()
             os.rename(self.path, self.path_part)
             raise
 
-    def put(self, tenant: str, uri_filename: str = None) -> None:
-        if not self.custom_content_type:
-            self.target_file.close()
-            os.rename(self.path, self.path_part)
-        elif self.custom_content_type == "application/octet-stream+nacl":
-            if self.nacl_stream_buffer:
-                decrypted = libnacl.crypto_stream_xor(
-                    self.nacl_stream_buffer, self.nacl_nonce, self.nacl_key
+    def store_processed_data(self, data: bytes):
+        self.target_file.write(data)
+
+    def store_processed_data_with_resumable(self, data: bytes):
+        self.res.add_chunk(self.target_file, data)
+
+    class DataBuffer:
+        """
+        Data buffers that when called accumulate received data but also immediately remove and yield it iff the volume crosses a threshold. This ensures the yielded data is always of sufficiently large volume but also that the volume never grows much past the threshold. Accumulation and removal are done on FIFO (first-in-first-out) basis -- data accumulated first are removed and yielded first.
+        """
+
+        def __init__(self, threshold: int):
+            self._buffer = b""
+            self._threshold = threshold
+
+        def __call__(self, data: bytes):
+            self._buffer += data
+            if len(self._buffer) >= self._threshold:
+                yield self._buffer
+                self._buffer = b""
+
+        def close(self):
+            """
+            Ensure that with the next calling of the buffer _all_ of the accumulated data is yielded (if there's any). This allows consumption of the last portion of data remaining in the buffer.
+            """
+            self._threshold = len(self._buffer) or 1
+
+    class NaclDataBuffer(DataBuffer):
+        """
+        Data buffers for requests with NaCl-encrypted data specifically.
+
+        These act the same way as `DataBuffer` except that a) accumulated data are yielded _decrypted_ and b) are always vended in chunks of size _matching_ the threshold.
+        """
+
+        def __init__(self, threshold: int, nonce, key):
+            super().__init__(threshold)
+            self._nonce = nonce
+            self._key = key
+
+        def __call__(self, data: bytes):
+            """
+            Add data to the buffer, iff there's enough data accumulated in the buffer to decrypt a block, remove one block worth of it from the buffer, decrypt the block and yield it.
+            """
+            self._buffer += data
+            while len(self._buffer) >= self._threshold:
+                yield libnacl.crypto_stream_xor(
+                    self._buffer[: self._threshold], self._nonce, self._key
                 )
-                self.nacl_stream_buffer = b""
-                self.target_file.write(decrypted)
-            self.target_file.close()
-            os.rename(self.path, self.path_part)
+                self._buffer = self._buffer[self._threshold :]
+
+    def _process_remaining_received_data(self):
+        """
+        Process remaining data which may have been left in the buffer (e.g. not crossed the threshold).
+        """
+        self.data_buffer.close()
+        self.data_received(b"")
+
+    def put(self, tenant: str, uri_filename: str = None) -> None:
+        self._process_remaining_received_data()
+        self.target_file.close()
+        os.rename(self.path, self.path_part)
         self.set_status(HTTPStatus.CREATED.value)
         self.write({"message": "data streamed"})
 
     async def patch(self, tenant: str, uri_filename: str = None) -> None:
-        if (
-            self.custom_content_type == "application/octet-stream+nacl"
-            and self.nacl_stream_buffer
-        ):
-            decrypted = libnacl.crypto_stream_xor(
-                self.nacl_stream_buffer, self.nacl_nonce, self.nacl_key
-            )
-            self.nacl_stream_buffer = b""
-            self.res.add_chunk(self.target_file, decrypted)
+        self._process_remaining_received_data()
         if __debug__:
             merge_chunk_verify = {}
             query = {

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1321,13 +1321,12 @@ class FileRequestHandler(AuthRequestHandler):
             self.finish()
 
     @RequestHandler.run_in_request_processing_context  # For reasons, Tornado evidently runs `data_received` in a _distinct_ context (different from the one we load in `prepare`), so we "force" ours (to retain request ID correlation, among other things)
-    @gen.coroutine
-    def data_received(self, data: bytes) -> Optional[Awaitable[None]]:
+    async def data_received(self, data: bytes) -> Optional[Awaitable[None]]:
         if __debug__ and hasattr(self, "received_data_length"):
             self.received_data_length += len(data)
         try:
             for processed in self.data_buffer(data):
-                self.store_processed_data(processed)
+                await to_thread(self.store_processed_data, processed)
         except:
             if self.target_file:
                 self.target_file.close()
@@ -1384,22 +1383,22 @@ class FileRequestHandler(AuthRequestHandler):
                 )
                 self._buffer = self._buffer[self._threshold :]
 
-    def _process_remaining_received_data(self):
+    async def _process_remaining_received_data(self):
         """
         Process remaining data which may have been left in the buffer (e.g. not crossed the threshold).
         """
         self.data_buffer.close()
-        self.data_received(b"")
+        await self.data_received(b"")
 
-    def put(self, tenant: str, uri_filename: str = None) -> None:
-        self._process_remaining_received_data()
+    async def put(self, tenant: str, uri_filename: str = None) -> None:
+        await self._process_remaining_received_data()
         self.target_file.close()
         os.rename(self.path, self.path_part)
         self.set_status(HTTPStatus.CREATED.value)
         self.write({"message": "data streamed"})
 
     async def patch(self, tenant: str, uri_filename: str = None) -> None:
-        self._process_remaining_received_data()
+        await self._process_remaining_received_data()
         if __debug__:
             merge_chunk_verify = {}
             query = {

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -1299,8 +1299,12 @@ class FileRequestHandler(AuthRequestHandler):
                     )
 
                 if self.request.method != "PATCH" or not self.completed_resumable_file:
-                    self.target_file = open(self.path, filemode, buffering=0)
-                    os.chmod(self.path, _RW______)
+                    self.target_file = open(
+                        self.path,
+                        filemode,
+                        buffering=0,
+                        opener=functools.partial(os.open, mode=_RW______),
+                    )
 
                 if self.request.method == "PATCH":
                     self.store_processed_data = self.store_processed_data_with_resumable


### PR DESCRIPTION
This is just a unit of  development work that includes additional off-loading of processing done as part of importing data. So while there's the latter, there are other related and unrelated changes.

I chose to consolidate specifically handling of different profile of request body data, with a "data buffer" abstraction. This eliminates more of `if` sentences that become quite prevalent with the potentially growing number of "axis" we have -- content type and method, for example. Meaning the API often has to do sufficiently different work depending on the content type and the method of a request being handled by a single class.

The consolidation and the more superficial related changes, were also done to facilitate off-loading (don't want to sprinkle `to_thread` where doing so could be avoided in favour of just expressing it _once_).

Anyway, I made an effort to explain each commit with its message, and the changes with each are for the most part independent of one another, really.