### PR TITLE
build(deps): add psycopg C optimisation extra

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -308,7 +308,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -873,6 +873,7 @@ files = [
 ]
 
 [package.dependencies]
+psycopg-c = {version = "3.3.4", optional = true, markers = "implementation_name != \"pypy\" and extra == \"c\""}
 psycopg-pool = {version = "*", optional = true, markers = "extra == \"pool\""}
 typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
@@ -884,6 +885,18 @@ dev = ["ast-comments (>=1.1.2)", "black (>=26.1.0)", "codespell (>=2.2)", "cytho
 docs = ["Sphinx (>=9.1)", "furo (==2025.12.19)", "sphinx-autobuild (>=2025.8.25)", "sphinx-autodoc-typehints (>=3.10.2)"]
 pool = ["psycopg-pool"]
 test = ["anyio (>=4.0)", "mypy (>=1.19.0) ; implementation_name != \"pypy\"", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
+
+[[package]]
+name = "psycopg-c"
+version = "3.3.4"
+description = "PostgreSQL database adapter for Python -- C optimisation distribution"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "implementation_name != \"pypy\""
+files = [
+    {file = "psycopg_c-3.3.4.tar.gz", hash = "sha256:ed8106128b2d04359c185fc9641b4409abfce4d0b6fb1d1ff6800646e27f1a22"},
+]
 
 [[package]]
 name = "psycopg-pool"
@@ -1467,4 +1480,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "0e475471b815a4fd9978b8fe13d99c1bb2e3957f224bb7f29cfa2a4f98b49801"
+content-hash = "cc3673cb1b30e8a8c4b46279fe3ec11f7af8d9ab34b39725eeefc838b30153e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ termcolor = ">=1.1.0"
 python-magic = ">=0.4.15"
 pyyaml = ">=5.4"
 pyresumable = ">=0.0.7"
-psycopg = ">=3.3.4"
+psycopg = { version = ">=3.3.4", extras = ["c"] }
 aiosqlite = ">=0.22.1"
 aio-pika = ">=9.6.2"
 


### PR DESCRIPTION
This makes psycopg link dynamically against the system libpq via a compiled C extension, which is faster than the pure-Python codepath and is the install approach the psycopg maintainers recommend for production use.

It also fixes startup crashes our containers have been hitting since the switch to psycopg 3: the pure-Python codepath needs an unversioned libpq.so symlink that neither Alpine's libpq nor Debian's libpq runtime packages provide.