### PR TITLE
RabbitMQ publishing fix

### DIFF
--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -216,7 +216,7 @@ async def _drain_cache(client: AmqpClient, cache: asyncio.Queue) -> None:
                 timestamp=msg["timestamp"],
             )
         except Exception as e:
-            logger.error(f"cache drain failed, re-queueing: {e}")
+            logger.error(f"cache drain failed, re-queueing: {e!r}")
             cache.put_nowait(msg)
             return
 
@@ -547,7 +547,7 @@ class AuthRequestHandler(RequestHandler):
             await _drain_cache(client, options.rabbitmq_cache)
         except Exception as e:
             logger.error(
-                f"problem publishing message: ex={ex} rkey={rkey} ver={ver}: {e}"
+                f"problem publishing message: ex={ex} rkey={rkey} ver={ver}: {e!r}"
             )
             options.rabbitmq_cache.put_nowait(
                 {

--- a/tsdfileapi/api.py
+++ b/tsdfileapi/api.py
@@ -3262,11 +3262,9 @@ class Backends:
             colored(f"Backend: {name}, ", "cyan"),
             colored(f"rabbitmq settings: {mq_config}", "yellow"),
         )
-        existing_exchanges = []
-        for name, config in self.exchanges.items():
-            existing_exchanges.append(config.get("exchange"))
+        existing_exchanges = {cfg.get("exchange") for cfg in self.exchanges.values()}
         if (
-            not self.exchanges.get(name)
+            name not in self.exchanges
             and mq_config.get("exchange") not in existing_exchanges
         ):
             self.exchanges[name] = mq_config

--- a/tsdfileapi/exc.py
+++ b/tsdfileapi/exc.py
@@ -208,3 +208,21 @@ def error_for_exception(exc: Exception, details: str = "") -> Error:
         message = generate_message([default.phrase, exc, details])
         headers = {}
     return Error(status, reason, message, headers)
+
+
+# AMQP errors
+# -----------
+
+
+class ExchangeNotDeclaredError(RuntimeError):
+    """Raised when publishing to an exchange that AmqpClient never declared."""
+
+    def __init__(self, exchange: str, known: list[str]) -> None:
+        self.exchange = exchange
+        self.known = known
+        known_repr = ", ".join(sorted(known)) if known else "<none>"
+        super().__init__(
+            f"exchange {exchange!r} was not declared at AmqpClient startup "
+            f"(declared exchanges: {known_repr}); check the backend's mq.exchange "
+            f"setting and that find_exchanges() picked it up"
+        )

--- a/tsdfileapi/rmq.py
+++ b/tsdfileapi/rmq.py
@@ -6,6 +6,8 @@ import uuid
 
 import aio_pika
 
+from tsdfileapi.exc import ExchangeNotDeclaredError
+
 logger = logging.getLogger(__name__)
 
 
@@ -85,7 +87,10 @@ class AmqpClient:
             timestamp=timestamp if timestamp is not None else int(time.time()),
             message_id=str(uuid.uuid4()),
         )
-        ex = self._exchanges[exchange]
+        try:
+            ex = self._exchanges[exchange]
+        except KeyError:
+            raise ExchangeNotDeclaredError(exchange, list(self._exchanges))
         await ex.publish(message, routing_key=routing_key)
 
     async def close(self) -> None:


### PR DESCRIPTION
This removes a variable redeclaration in `find_exchanges()` that made `self.exchanges` only get a single entry defined. The refactored `AmqpClient` relies on the data from this variable for binding to exchanges and would then fail to publish messages.