### PR TITLE
aio.os: Fix an omission issue in `walk`

### DIFF
--- a/tsdfileapi/aio/os.py
+++ b/tsdfileapi/aio/os.py
@@ -111,7 +111,8 @@ async def walk(top, topdown=True, onerror=None, followlinks=False):
                             try:
                                 is_symlink = entry.is_symlink()
                             except OSError as error:
-                                onerror(error)
+                                if onerror is not None:
+                                    onerror(error)
                                 is_symlink = False
                         if followlinks or not is_symlink:
                             walk_dirs.append(entry.path)


### PR DESCRIPTION
The `onerror` may be `None` by upstream (`os.walk` proper) interface, which should have the effect of not calling `onerror` (as if it was a no-op).